### PR TITLE
Use a proper GITHUB_TOKEN in release GH Action

### DIFF
--- a/.changeset/empty-houses-drop.md
+++ b/.changeset/empty-houses-drop.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+Fix release GH Action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           publish: yarn release
           commit: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.TOPTAL_BUILD_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add no-jira label to "Version Package" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}


### PR DESCRIPTION
### Description

use the proper secret token in release GH Action

### How to test

- Merge the PR and check

### Review

- [x] Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed
