### PR TITLE
fix: fix typo for alpha-release action

### DIFF
--- a/build-publish-alpha-package/README.md
+++ b/build-publish-alpha-package/README.md
@@ -14,8 +14,8 @@ The list of arguments, that are used in GH Action:
 
 | name        | type   | required | default | description                                           |
 | ----------- | ------ | -------- | ------- | ----------------------------------------------------- |
-| `npm-token` | string | ✅        |         | Name of the branch that will be published             |
-| `branch`    | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
+| `npm-token` | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
+| `branch`    | string | ✅        |         | Name of the branch that will be published             |
 
 ### Outputs
 

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -8,10 +8,10 @@ outputs:
 inputs:
   npm-token:
     required: true
-    description: 'Name of the branch that will be published || string'
+    description: 'NPM token used for publishing. Has to be type Publish || string'
   branch:
     required: true
-    description: 'NPM token used for publishing. Has to be type Publish || string'
+    description: 'Name of the branch that will be published || string'
 
 runs:
   using: composite


### PR DESCRIPTION
No-jira

### Description

Fix a typo for command description of alpha-release

### How to test

- code review is enough

### Review

- Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed
