### PR TITLE
chore: remove single quotes from title

### DIFF
--- a/.changeset/warm-steaks-eat.md
+++ b/.changeset/warm-steaks-eat.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- Remove single quotes from PR title in the notify jira about contribution

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -65,9 +65,10 @@ runs:
       env:
         JIRA_HOOK: ${{ inputs.jira-hook }}
         REPO: ${{ inputs.repo }}
+        TITLE: ${{ fromJson(steps.get-pr.outputs.data) }} | tr -d "'"
       run: |
         curl -X POST -H 'Content-type: application/json' \
-        --data '{"data": {"author":"${{fromJson(steps.get-pr.outputs.data).user.login}}", "author_url":"${{fromJson(steps.get-pr.outputs.data).user.html_url}}", "title":"${{fromJson(steps.get-pr.outputs.data).title}}", "number":"${{fromJson(steps.get-pr.outputs.data).number}}", "url":"${{fromJson(steps.get-pr.outputs.data).html_url}}", "repo":"$REPO"}}' \
+        --data '{"data": {"author":"${{fromJson(steps.get-pr.outputs.data).user.login}}", "author_url":"${{fromJson(steps.get-pr.outputs.data).user.html_url}}", "title":"$TITLE", "number":"${{fromJson(steps.get-pr.outputs.data).number}}", "url":"${{fromJson(steps.get-pr.outputs.data).html_url}}", "repo":"$REPO"}}' \
         $JIRA_HOOK
 
     - name: Greet author


### PR DESCRIPTION
[FX-NNNN]

### Description

- In notify jira about contribution workflow, we have: `--data '..."title": ...` We should escape/remove single quotes for the title

### How to test

- FIXME: Add the steps describing how to verify your changes

### Review

- [x] Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed
