### PR TITLE
Add a custom davinci branch in build-push-image GH Action

### DIFF
--- a/.changeset/swift-seas-happen.md
+++ b/.changeset/swift-seas-happen.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- Add ability to specify a custom davinci branch in build-push-image GH Action

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -12,13 +12,14 @@ This GH Action builds a Docker image and pushes to google cloud.
 
 The list of arguments, that are used in GH Action:
 
-| name          | type                                                        | required | default                                             | description                                                                                |
-| ------------- | ----------------------------------------------------------- | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `sha`         | string                                                      | ✅        |                                                     | Commit hash that will be used as a tag for the Docker image                                |
-| `image-name`  | string                                                      | ✅        |                                                     | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
-| `environment` | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
-| `build-args`  | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
-| `docker-file` | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
+| name             | type                                                        | required | default                                             | description                                                                                |
+| ---------------- | ----------------------------------------------------------- | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `sha`            | string                                                      | ✅        |                                                     | Commit hash that will be used as a tag for the Docker image                                |
+| `image-name`     | string                                                      | ✅        |                                                     | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
+| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
+| `build-args`     | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
+| `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
+| `davinci-branch` | string                                                      |          |                                                     | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -27,7 +27,7 @@ inputs:
   davinci-branch:
     description: 'Custom davinci branch'
     required: false
-    default: ''
+    default: 'master'
 
 runs:
   using: composite

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'pathname to Docker file'
     required: false
     default: ./davinci/packages/ci/src/configs/docker/Dockerfile
+  davinci-branch:
+    description: 'Custom davinci branch'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -34,6 +38,7 @@ runs:
         repository: toptal/davinci
         token: ${{ env.GITHUB_TOKEN }}
         path: davinci
+        ref: ${{ inputs.davinci-branch }}
 
     - name: Setup node
       uses: actions/setup-node@v3.2.0


### PR DESCRIPTION
### Description

In order to be able to test davinci stuff, we need to pass a custom davinci branch

### How to test

- Test it in a separate repo via branch tag

### Review

- [x] Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed
