### PR TITLE
feat: add build-push-storybook-image action

### DIFF
--- a/.changeset/short-bags-explode.md
+++ b/.changeset/short-bags-explode.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### build-push-storybook-image
+
+- new action for build & push storybook image to the cloud

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -19,7 +19,7 @@ The list of arguments, that are used in GH Action:
 | `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
 | `build-args`     | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
 | `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
-| `davinci-branch` | string                                                      |          |                                                     | Custom davinci branch                                                                      |
+| `davinci-branch` | string                                                      |          | master                                              | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/build-push-storybook-image/README.md
+++ b/build-push-storybook-image/README.md
@@ -1,0 +1,43 @@
+## Build & Push Storybook Docker Image
+
+Builds a release image of Storybook and pushes it to the cloud.
+
+### Description
+
+Before using this action, `yarn install` should be executed.
+
+This action uses `yarn storybook:build` command to build storybook and expects the output in the folder `./storybook-static`
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name             | type   | required | default            | description                                                 |
+| ---------------- | ------ | -------- | ------------------ | ----------------------------------------------------------- |
+| `sha`            | string | ✅        |                    | Commit hash that will be used as a tag for the Docker image |
+| `davinci-branch` | string |          | master             | Custom davinci branch                                       |
+| `dist-folder`    | string |          | ./storybook-static | Path to folder where Storybook is built                     |
+| `build-command`  | string |          | storybook:build    | Command to build Storybook with                             |
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
+This is a list of ENV Variables that are used in GH Action:
+
+| name              | description                                        |
+| ----------------- | -------------------------------------------------- |
+| `GITHUB_TOKEN`    | GitHub token. Is used to checkout `davinci` branch |
+| `GCR_ACCOUNT_KEY` | Necessary token to push image to Google cloud      |
+
+### Usage
+
+```yaml
+  - uses: toptal/davinci-github-actions/yarn-install@v3.2.0
+  - uses: toptal/davinci-github-actions/build-push-storybook-image@v3.2.0
+    with:
+      sha: 7042976bc3db21012fe38602bb643618a95aa2d0
+```

--- a/build-push-storybook-image/action.yml
+++ b/build-push-storybook-image/action.yml
@@ -1,0 +1,53 @@
+name: Build & Push Storybook Docker Image
+
+description: |
+  Builds a release image of Storybook and pushes it to the cloud.
+  ****
+  envInputs:
+    GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
+    GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
+
+inputs:
+  sha:
+    description: Commit hash that will be used as a tag for the Docker image
+    required: true
+  davinci-branch:
+    description: Custom davinci branch
+    required: false
+    default: master
+  dist-folder:
+    description: Path to folder where Storybook is built
+    required: false
+    default: ./storybook-static
+  build-command:
+    description: Command to build Storybook with
+    required: false
+    default: storybook:build
+
+runs:
+  using: composite
+  steps:
+    - name: Build Storybook
+      shell: bash
+      env:
+        BUILD_COMMAND: ${{ inputs.build-command }}
+      run: yarn "$BUILD_COMMAND"
+
+    - name: Specify repository name
+      id: get-repo
+      shell: bash
+      run: echo ::set-output name=repository_name::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")
+
+    - name: Build and Push Storybook Image
+      uses: toptal/davinci-github-actions/build-push-image@v3.1.0
+      with:
+        sha: ${{ inputs.sha }}
+        image-name: ${{ steps.get-repo.outputs.repository_name }}-storybook-release
+        build-args: |
+          DIST_FOLDER=${{ inputs.dist-folder }}
+          NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost-storybook.conf
+          VERSION=${{ inputs.sha }}
+        docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.storybook
+        davinci-branch: ${{ inputs.davinci-branch }}
+
+


### PR DESCRIPTION
[FX-2903]

### Description

Create reausable GHA for build of Storybook Docker image & push it to the cloud

### How to test

- the action is used inside [topapp](https://github.com/toptal/topapp-frontend/blob/3440f09a69321297b400a096cd1454437f081b2a/.github/workflows/davinci-deploy-storybook-staging.yml#L46-L48) in [this PR](https://github.com/toptal/topapp-frontend/pull/104)
- you can rerun the [action that takes care of build&push of storybook image](https://github.com/toptal/topapp-frontend/runs/7091097470?check_suite_focus=true) and check if its being published [in the cloud](https://console.cloud.google.com/gcr/images/toptal-hub/GLOBAL/topapp-frontend-storybook?authuser=1)

### Review

- [x] Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed


[FX-2903]: https://toptal-core.atlassian.net/browse/FX-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ