### PR TITLE
feat: implement Deploy Storybook GH Action

### DIFF
--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -19,7 +19,7 @@ The list of arguments, that are used in GH Action:
 | `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
 | `build-args`     | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
 | `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
-| `davinci-branch` | string                                                      |          |                                                     | Custom davinci branch                                                                      |
+| `davinci-branch` | string                                                      |          | master                                              | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -1,0 +1,40 @@
+## Deploy Storybook to a particular environment
+
+Builds and Deploys an Application's storybook to a particular environment
+
+### Description
+
+This action builds and pushes **Storybook** Docker image to the hub and trigger an appropriate **Jenkins** job to deploy image to a particular environment: `staging` or `temploy`
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name             | type   | required | default | description                                                 |
+| ---------------- | ------ | -------- | ------- | ----------------------------------------------------------- |
+| `sha`            | string | ✅        |         | Commit hash that will be used as a tag for the Docker image |
+| `davinci-branch` | string |          | master  | Custom davinci branch                                       |
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
+This is a list of ENV Variables that are used in GH Action:
+
+| name                   | description                                        |
+| ---------------------- | -------------------------------------------------- |
+| `GITHUB_TOKEN`         | GitHub token. Is used to checkout `davinci` branch |
+| `GCR_ACCOUNT_KEY`      | Necessary token to push image to Google cloud\\    |
+| `JENKINS_DEPLOY_TOKEN` | Jenkins deployment token                           |
+
+### Usage
+
+```yaml
+  - uses: toptal/davinci-github-actions/deploy-storybook@v3.2.0
+    with:
+      sha: 7042976bc3db21012fe38602bb643618a95aa2d0
+
+```

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -1,0 +1,47 @@
+name: Deploy Storybook to a particular environment
+description: |
+  Builds and Deploys an Application's storybook to a particular environment
+  ****
+  envInputs:
+    GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
+    GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud\
+    JENKINS_DEPLOY_TOKEN: Jenkins deployment token
+
+inputs:
+  sha:
+    required: true
+    description: 'Commit hash that will be used as a tag for the Docker image'
+  davinci-branch:
+    description: Custom davinci branch
+    required: false
+    default: master
+
+runs:
+  using: composite
+  steps:
+    - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
+
+    - uses: toptal/davinci-github-actions/build-push-storybook-image@fx-2903-create-partial-gh-action-for-storybook-temploy
+      name: Build & Push Docker image
+      with:
+        sha: ${{ inputs.sha }}
+        davinci-branch: ${{ inputs.davinci-branch }}
+
+    - name: Specify repository name
+      id: get-repo
+      shell: bash
+      run: echo ::set-output name=repository_name::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")
+
+    - name: Trigger temploy job
+      uses: toptal/jenkins-job-trigger-action@1.0.0
+      with:
+        jenkins_url: https://jenkins.toptal.net
+        jenkins_user: toptal-devbot
+        jenkins_token: ${{ env.JENKINS_DEPLOY_TOKEN }}
+        job_name: '${{ steps.get-repo.outputs.repository_name }}/job/${{ steps.get-repo.outputs.repository_name }}-storybook-staging-deployment'
+        job_params: |
+          {
+            "TAG": "${{ inputs.sha }}",
+            "HELM_BRANCH": "feat/reusable-storybook"
+          }
+        job_timeout: '1200'


### PR DESCRIPTION
[FX-2904]

### Description

Implement reusable GH Action to be able to deploy Storybook application to staging/temploy

### How to test

- Reuse it in the GH Workflow, for ex.: toptapp-frontend

### Review

- [ ] Ensure that new GH Action have a README.md file
- [ ] Ensure that `yarn documentation:generate` was executed


[FX-2904]: https://toptal-core.atlassian.net/browse/FX-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ