### PR TITLE
feat: make docs generate automatically

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,3 @@ Describe the changes and motivations for the pull request, unless evident from t
 ### How to test
 
 - FIXME: Add the steps describing how to verify your changes
-
-### Review
-
-- [ ] Ensure that new GH Action have a README.md file
-- [ ] Ensure that `yarn documentation:generate` was executed

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  '*.{js,jsx,ts,tsx}': ['davinci syntax lint code', 'prettier --write'],
+  '{action.yml,README.md}': paths =>
+    paths.length > 0
+      ? ['yarn documentation:generate', `git add */README.md`]
+      : []
+}

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -19,7 +19,7 @@ The list of arguments, that are used in GH Action:
 | `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
 | `build-args`     | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
 | `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
-| `davinci-branch` | string                                                      |          |                                                     | Custom davinci branch                                                                      |
+| `davinci-branch` | string                                                      |          | master                                              | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "release": "changeset tag",
     "lint": "davinci syntax lint code .",
     "test": "davinci qa unit --runInBand",
-    "test:ci": "LANG=en_US davinci qa unit --ci --testTimeout=10000 --silent"
+    "test:ci": "LANG=en_US davinci qa unit --ci --testTimeout=10000 --silent",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@actions/core": "^1.6.0",
@@ -34,11 +35,5 @@
     "typescript": "^4.6.4",
     "unified": "^10.1.2",
     "@vercel/ncc": "^0.34.0"
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "davinci syntax lint code",
-      "prettier --write"
-    ]
   }
 }


### PR DESCRIPTION
### Description

Run generation of documentation automatically on lint-staged files if any changed files is `action.yml` or `README.md`.
With this, we can simplify PR template and not require the checklist (first check is done automatically and for second check we have a workflow test)

### How to test

You can test it locally:

- create a testing branch locally by running: `git fetch && git branch --no-track feat/test-branch origin/feat/generate-docs-automatically && git checkout feat/test-branch`
- run `yarn install` just to be sure you have husky prepared locally
- change any `action.yml` file, for example `build-push-image/action.yml:18` change default to `temploy`
- run `git commit -am"test: update default value"`
- check contents of `build-push-image/README.md` to see if default value for `environment` equals to `temploy`

### Review

- [x] Ensure that new GH Action have a README.md file
- [x] Ensure that `yarn documentation:generate` was executed
