### PR TITLE
fix: rename release name for storybook temploy

### DIFF
--- a/.changeset/kind-mails-attend.md
+++ b/.changeset/kind-mails-attend.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- Rename release name for storybook temploy

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -115,5 +115,6 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const body = 'Storybook temploy is available at https://${{ env.RELEASE }}.toptal.rocks :tada:'
+          const name = ['${{ env.RELEASE }}', '${{ env.REPOSITORY_NAME }}-storybook'].join('-').substring(0, 45)
+          const body = 'Storybook temploy is available at https://${{ name }}.toptal.rocks :tada:'
           github.issues.createComment({ issue_number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -115,6 +115,6 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', '${{ env.REPOSITORY_NAME }}-storybook'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           github.issues.createComment({ issue_number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: |
         echo ::set-output name=repository_name::${{ github.event.repository.name }}
-        echo ::set-output name=release_name::${{ github.event.repository.name }}-storybook-pr-${{ github.event.number || github.event.issue.number }}
+        echo ::set-output name=release_name::${{ github.event.repository.name }}-pr-${{ github.event.number || github.event.issue.number }}-storybook
 
     - name: Build and Push Storybook Image
       uses: toptal/davinci-github-actions/build-push-image@v3.2.0

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -116,5 +116,5 @@ runs:
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ env.REPOSITORY_NAME }}-storybook'].join('-').substring(0, 45)
-          const body = 'Storybook temploy is available at https://${{ name }}.toptal.rocks :tada:'
+          const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           github.issues.createComment({ issue_number, owner, repo, body })


### PR DESCRIPTION
### Description

The current name format is breaking the temploy cleaner: https://github.com/toptal/topapp-frontend/blame/master/.github/workflows/davinci-deploy-storybook-staging.yml#L77, since it expects the words before pr-number to be the repository name.
We must rename it

### How to test

- Test it in topapp application

Checked here: https://github.com/toptal/topapp-frontend/pull/119
