### PR TITLE
fix: using one source of truth for PR owner

### DIFF
--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Define if PR is eligible - PR authored by external contributor and is not draft
       env:
-        IS_NOT_DEPENDABOT_BOT: ${{ github.actor != 'dependabot[bot]' }}
+        IS_NOT_DEPENDABOT_BOT: ${{ fromJson(steps.get-pr.outputs.data).user.login != 'dependabot[bot]' }}
       id: is-pr-eligible
       shell: bash
       run: |


### PR DESCRIPTION
### Description

We used two ways to determine PR owner:

1. from action `octokit/request-action` -> outputs.user.login
2. from context `github.actor`

But lately these values didnt match, because [some flaky tickets](https://toptal-core.atlassian.net/browse/FX-2946) were created. 
In the workflow run I can only inspect the 1. value (its used as an input to action) and I can see its correct, therefore I want to use this value instead of `github.actor`. 

Advantages are:

- single source of truth for github owner
- the value is visible in the workflow run so it can be debugged later if flaky ticket is created again

### How to test

- check that the value used for comparison is the same as used on line 39
