### PR TITLE
feat: add development checks with changeset to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,7 @@ Describe the changes and motivations for the pull request, unless evident from t
 ### How to test
 
 - FIXME: Add the steps describing how to verify your changes
+
+### Development checks
+
+- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

--- a/_docs/contribution/changeset-guidelines.md
+++ b/_docs/contribution/changeset-guidelines.md
@@ -1,0 +1,42 @@
+# Changesets guidelines
+
+The same as commits, we write changeset in `present simple`.
+
+## Version bump
+
+`patch`
+
+- Bug fix
+- Change in the existing functionality
+- Change, which does not affect users
+
+`minor`
+
+- New action
+- New action input/output
+
+`major`
+
+- Deleting an action
+- Deleting an action's input/output
+- Users need to take action to use released version with the changes
+
+## Summary of the change (changelog message)
+
+Please use this format:
+
+```
+---
+'davinci-github-actions': [version bump]
+---
+
+---
+### action name 1
+
+- change 1 for the action 1
+
+### action name 2
+
+- change 1 for the action 2
+- change 2 for the action 2
+```


### PR DESCRIPTION
### Description

Extend PR template with development checks and add changeset reminder there

### How to test

I've added the section to this PR, so this is pretty much how it's going to look

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/5fa5ac9a0fdcfeb7c43f0c0018f62034ca04da41/_docs/contribution/changeset-guidelines.md) (if needed)

