### PR TITLE
feat: [FX-2929] Add path parameter to yarn-install action

### DIFF
--- a/.changeset/proud-mails-whisper.md
+++ b/.changeset/proud-mails-whisper.md
@@ -4,4 +4,4 @@
 
 ---
 
-- Add `path` parameter to specify the directory to run yarn
+- Add `path` parameter to specify the directory where to run `yarn install` command

--- a/.changeset/proud-mails-whisper.md
+++ b/.changeset/proud-mails-whisper.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+- Add `path` parameter to specify the directory to run yarn

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -14,6 +14,7 @@ The list of arguments, that are used in GH Action:
 | --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `npm-token`     | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
 | `cache-version` | string |          | 0.0     | Cache version                                                                                                             |
+| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where about to run yarn install                                                    |
 
 ### Outputs
 

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -14,7 +14,7 @@ The list of arguments, that are used in GH Action:
 | --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `npm-token`     | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
 | `cache-version` | string |          | 0.0     | Cache version                                                                                                             |
-| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where about to run yarn install                                                    |
+| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
 
 ### Outputs
 

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Cache version'
     default: '0.0'
     required: false
+  path:
+    description: Relative path under $GITHUB_WORKSPACE where about to run yarn install
+    default: .
+    required: false
 outputs:
   cache-hit:
     description: 'Indicates an exact match was found for `node_modules` || boolean'
@@ -28,6 +32,7 @@ runs:
     # This step is needed only because we want to update the cache when a new workspace
     # package has been added and we want symlinks to be presented in ./node_modules folder
     - name: Generate workspaces info
+      working-directory: ${{ inputs.path }}
       run: |
         if grep -q "\"workspaces\":" package.json; then
             yarn --no-default-rc workspaces --json info > tmp-workspaces.json
@@ -50,6 +55,7 @@ runs:
 
     - name: yarn install
       shell: bash
+      working-directory: ${{ inputs.path }}
       env:
         NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: '0.0'
     required: false
   path:
-    description: Relative path under $GITHUB_WORKSPACE where about to run yarn install
+    description: Relative path under $GITHUB_WORKSPACE where to run `yarn install` command
     default: .
     required: false
 outputs:


### PR DESCRIPTION
[FX-2929]

### Description

I have a case when I need to specify a folder where I run my `yarn install`. In this case, prior to creating a temploy image I need to:
- checkout my project
- checkout davinci repo
- yarn install my project
- build my project
- create a docker image from Davinci and my project dist files

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)


[FX-2929]: https://toptal-core.atlassian.net/browse/FX-2929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ