### PR TITLE
feat: allow custom install commands on yarn-install

### DIFF
--- a/.changeset/ten-dryers-run.md
+++ b/.changeset/ten-dryers-run.md
@@ -5,4 +5,4 @@
 ---
 ### yarn-install
 
-- allow yarn-install commands to be optionally added.
+- remove --ignore-optional flag from the yarn install command.

--- a/.changeset/ten-dryers-run.md
+++ b/.changeset/ten-dryers-run.md
@@ -1,0 +1,8 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+### yarn-install
+
+- allow yarn-install commands to be optionally added.

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -10,11 +10,12 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 
 The list of arguments, that are used in GH Action:
 
-| name            | type   | required | default | description                                                                                                               |
-| --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `npm-token`     | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
-| `cache-version` | string |          | 0.0     | Cache version                                                                                                             |
-| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
+| name              | type   | required | default                                                   | description                                                                                                               |
+| ----------------- | ------ | -------- | -------                                                   | ------------------------------------------------------------------------------------------------------------------------- |
+| `npm-token`       | string |          |                                                           | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
+| `cache-version`   | string |          | 0.0                                                       | Cache version                                                                                                             |
+| `path`            | string |          | .                                                         | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
+| `install-options` | string |          | '--frozen-lockfile --ignore-optional --non-interactive'   | Additional options to use when running the `yarn install` command                                                         |
 
 ### Outputs
 

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -10,12 +10,11 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 
 The list of arguments, that are used in GH Action:
 
-| name              | type   | required | default                                                   | description                                                                                                               |
-| ----------------- | ------ | -------- | -------                                                   | ------------------------------------------------------------------------------------------------------------------------- |
-| `npm-token`       | string |          |                                                           | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
-| `cache-version`   | string |          | 0.0                                                       | Cache version                                                                                                             |
-| `path`            | string |          | .                                                         | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
-| `install-options` | string |          | '--frozen-lockfile --ignore-optional --non-interactive'   | Additional options to use when running the `yarn install` command                                                         |
+| name            | type   | required | default | description                                                                                                               |
+| --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `npm-token`     | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
+| `cache-version` | string |          | 0.0     | Cache version                                                                                                             |
+| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
 
 ### Outputs
 

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Relative path under $GITHUB_WORKSPACE where to run `yarn install` command
     default: .
     required: false
+  install-options:
+    description: Additional options to use when running the `yarn install` command
+    default: '--frozen-lockfile --ignore-optional --non-interactive'
+    required: false
 outputs:
   cache-hit:
     description: 'Indicates an exact match was found for `node_modules` || boolean'
@@ -59,4 +63,4 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
       run: |
-        yarn install --frozen-lockfile --ignore-optional --non-interactive
+        yarn install ${{ inputs.install-options }}

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -12,10 +12,6 @@ inputs:
     description: Relative path under $GITHUB_WORKSPACE where to run `yarn install` command
     default: .
     required: false
-  install-options:
-    description: Additional options to use when running the `yarn install` command
-    default: '--frozen-lockfile --ignore-optional --non-interactive'
-    required: false
 outputs:
   cache-hit:
     description: 'Indicates an exact match was found for `node_modules` || boolean'
@@ -63,4 +59,4 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
       run: |
-        yarn install ${{ inputs.install-options }}
+        yarn install --frozen-lockfile --non-interactive


### PR DESCRIPTION
[TDESKAPP-700]

### Description

Add the ability to run custom `yarn install` commands.

### How to test

- Run the `yarn-install` action pointing to `TDESKAPP-700-install-options`
Example: https://github.com/toptal/desktop-app/actions/runs/3044433958/jobs/4904817778

![image](https://user-images.githubusercontent.com/10238432/189883970-7b1405c6-b5ec-4794-848a-691c75f226cd.png)


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[TDESKAPP-700]: https://toptal-core.atlassian.net/browse/TDESKAPP-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ