### PR TITLE
feat: add dependency cruiser metrics report action

### DIFF
--- a/.changeset/cuddly-rats-report.md
+++ b/.changeset/cuddly-rats-report.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### depcuiser-metrics-report
+
+- add an action to report dependency cruiser metrics

--- a/depcuiser-metrics-report/README.md
+++ b/depcuiser-metrics-report/README.md
@@ -1,4 +1,4 @@
-## Depdendency cruiser metrics report
+## Dependency cruiser metrics report
 
 Generates a report for the project of dependency cruiser metrics
 
@@ -14,6 +14,7 @@ The list of arguments, that are used in GH Action:
 | -------------------- | ------ | -------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `npm-token`          | string |          |                                 | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
 | `report-output-path` | string |          | dependency-cruiser-results.json | Path to the metrics report json file                                                                                      |
+| `tsconfig-path`      | string |          | ./tsconfig.json                 | Path to the custom tsconifg.json file                                                                                     |
 
 ### Outputs
 

--- a/depcuiser-metrics-report/README.md
+++ b/depcuiser-metrics-report/README.md
@@ -14,7 +14,7 @@ The list of arguments, that are used in GH Action:
 | -------------------- | ------ | -------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `npm-token`          | string |          |                                 | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
 | `report-output-path` | string |          | dependency-cruiser-results.json | Path to the metrics report json file                                                                                      |
-| `tsconfig-path`      | string |          | ./tsconfig.json                 | Path to the custom tsconifg.json file                                                                                     |
+| `tsconfig-path`      | string |          | ./tsconfig.json                 | Path to the custom tsconfig.json file                                                                                     |
 
 ### Outputs
 

--- a/depcuiser-metrics-report/README.md
+++ b/depcuiser-metrics-report/README.md
@@ -1,0 +1,41 @@
+## Depdendency cruiser metrics report
+
+Generates a report for the project of dependency cruiser metrics
+
+### Description
+
+Generates a report for the project of dependency cruiser metrics
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name                 | type   | required | default                         | description                                                                                                               |
+| -------------------- | ------ | -------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `npm-token`          | string |          |                                 | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
+| `report-output-path` | string |          | dependency-cruiser-results.json | Path to the metrics report json file                                                                                      |
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+Not specified
+
+### Usage
+
+```yaml
+  - name: Generate the dependency cruiser metrics report
+    uses: toptal/davinci-github-actions/depcuiser-metrics-report@v4.2.2
+```
+
+or with inputs:
+
+```yaml
+  - name: Generate the dependency cruiser metrics report
+    uses: toptal/davinci-github-actions/depcuiser-metrics-report@v4.2.2
+    with:
+      npm-token: ${{ env.NPM_TOKEN }}
+      report-output-path: dependency-cruiser-results.json
+```

--- a/depcuiser-metrics-report/action.yml
+++ b/depcuiser-metrics-report/action.yml
@@ -19,6 +19,14 @@ runs:
         NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
       run: yarn add --dev dependency-cruiser -W
 
+    - name: Add tsconfig to include all available files
+      shell: bash
+      run: |
+        echo "{
+          \"extends\": \"./tsconfig.json\",
+          \"include\": [\"**/*\"]
+        }" > tsconfig.dependency-cruiser.json
+
     - name: Generate the dependency cruiser report
       shell: bash
       env:

--- a/depcuiser-metrics-report/action.yml
+++ b/depcuiser-metrics-report/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: dependency-cruiser-results.json
     required: false
   tsconfig-path:
-    description: Path to the custom tsconifg.json file
+    description: Path to the custom tsconfig.json file
     default: ./tsconfig.json
     required: false
 
@@ -25,9 +25,11 @@ runs:
 
     - name: Add tsconfig to include all available files
       shell: bash
+      env:
+        TS_CONFIG: ${{ inputs.tsconfig-path }}
       run: |
         echo "{
-          \"extends\": \"${{ inputs.tsconfig-path }}\",
+          \"extends\": \"${{ env.TS_CONFIG }}\",
           \"include\": [\"**/*\"]
         }" > tsconfig.dependency-cruiser.json
 

--- a/depcuiser-metrics-report/action.yml
+++ b/depcuiser-metrics-report/action.yml
@@ -1,4 +1,4 @@
-name: 'Depdendency cruiser metrics report'
+name: 'Dependency cruiser metrics report'
 description: 'Generates a report for the project of dependency cruiser metrics'
 
 inputs:
@@ -8,6 +8,10 @@ inputs:
   report-output-path:
     description: Path to the metrics report json file
     default: dependency-cruiser-results.json
+    required: false
+  tsconfig-path:
+    description: Path to the custom tsconifg.json file
+    default: ./tsconfig.json
     required: false
 
 runs:
@@ -23,7 +27,7 @@ runs:
       shell: bash
       run: |
         echo "{
-          \"extends\": \"./tsconfig.json\",
+          \"extends\": \"${{ inputs.tsconfig-path }}\",
           \"include\": [\"**/*\"]
         }" > tsconfig.dependency-cruiser.json
 

--- a/depcuiser-metrics-report/action.yml
+++ b/depcuiser-metrics-report/action.yml
@@ -32,4 +32,4 @@ runs:
       env:
         DEPCRUISER_CONFIG_PATH: ${{ github.action_path }}/dependency-cruiser-metrics-config.js
         REPORT_OUTPUT_PATH: ${{ inputs.report-output-path }}
-      run: yarn dependency-cruiser --config ${{ env.DEPCRUISER_CONFIG_PATH }} --metrics --output-to ${{ REPORT_OUTPUT_PATH }} --output-type json .
+      run: yarn dependency-cruiser --config ${{ env.DEPCRUISER_CONFIG_PATH }} --metrics --output-to ${{ env.REPORT_OUTPUT_PATH }} --output-type json .

--- a/depcuiser-metrics-report/action.yml
+++ b/depcuiser-metrics-report/action.yml
@@ -1,0 +1,27 @@
+name: 'Depdendency cruiser metrics report'
+description: 'Generates a report for the project of dependency cruiser metrics'
+
+inputs:
+  npm-token:
+    description: Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used
+    required: false
+  report-output-path:
+    description: Path to the metrics report json file
+    default: dependency-cruiser-results.json
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install dependency cruiser
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
+      run: yarn add --dev dependency-cruiser -W
+
+    - name: Generate the dependency cruiser report
+      shell: bash
+      env:
+        DEPCRUISER_CONFIG_PATH: ${{ github.action_path }}/dependency-cruiser-metrics-config.js
+        REPORT_OUTPUT_PATH: ${{ inputs.report-output-path }}
+      run: yarn dependency-cruiser --config ${{ env.DEPCRUISER_CONFIG_PATH }} --metrics --output-to ${{ REPORT_OUTPUT_PATH }} --output-type json .

--- a/depcuiser-metrics-report/dependency-cruiser-metrics-config.js
+++ b/depcuiser-metrics-report/dependency-cruiser-metrics-config.js
@@ -2,7 +2,7 @@ module.exports = {
   options: {
     tsPreCompilationDeps: true,
     tsConfig: {
-      fileName: 'tsconfig.depcruiser.json',
+      fileName: 'tsconfig.dependency-cruiser.json',
     },
     doNotFollow: 'node_modules',
     exclude: {

--- a/depcuiser-metrics-report/dependency-cruiser-metrics-config.js
+++ b/depcuiser-metrics-report/dependency-cruiser-metrics-config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  options: {
+    tsPreCompilationDeps: true,
+    tsConfig: {
+      fileName: 'tsconfig.depcruiser.json',
+    },
+    doNotFollow: 'node_modules',
+    exclude: {
+      path:
+        '(stories|dist|coverage|__[a-z]+__|_fixtures|cypress|_jest|_nyc|_scripts|scripts|tmp|_templates|.storybook|.testbox|ci|docs)',
+    },
+    reporterOptions: {
+      metrics: {
+        hideModules: false, // hides the modules from the metrics reporter output
+        hideFolders: false, // would hide folders from the metrics reporter output
+        orderBy: 'name', // possible values: name, moduleCount, afferentCouplings, efferentCouplings, instability
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Description

Add a new action to create a report from dependency cruiser metrics

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
