### PR TITLE
fix: incorrect reference to path-pattern

### DIFF
--- a/.changeset/red-waves-provide.md
+++ b/.changeset/red-waves-provide.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### no-untracked-generated-types
+
+- fix usage of path-pattern

--- a/no-untracked-generated-types/action.yml
+++ b/no-untracked-generated-types/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         UNTRACKED_CHANGES_COUNT=0
-        git status -s -u ${{ inputs.davinci-branch }} ':(exclude)untracked_changes.txt' > untracked_changes.txt
+        git status -s -u ${{ inputs.path-pattern }} ':(exclude)untracked_changes.txt' > untracked_changes.txt
         UNTRACKED_CHANGES_COUNT=`wc -l untracked_changes.txt | cut -c1`
         if [ $UNTRACKED_CHANGES_COUNT -gt 0 ]; then
           echo "Files with untracked changes found:"


### PR DESCRIPTION
[MAT-1783]

### Description

Instead of using `path-pattern` to find only GQL types files, it was referring to some testing variable, which does not exist.

### How to test

- [This check](https://github.com/toptal/client-portal/actions/runs/3385778567/jobs/5624334358)  on step "Check if ungenerated GQL types exist" -> "Run UNTRACKED_CHANGES_COUNT=0" should have this line `git status -s -u *.generated.ts ':(exclude)untracked_changes.txt' > untracked_changes.txt` with specified `path-pattern` on the check (`*.generated.ts`)
![image](https://user-images.githubusercontent.com/91321923/199724139-adc8a008-ade2-46a1-825d-34ef10a32b47.png)


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
