### PR TITLE
ci: add image push to gar

### DIFF
--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -57,16 +57,25 @@ runs:
       id: meta
       uses: docker/metadata-action@v4.0.1
       with:
-        images: gcr.io/toptal-hub/${{ inputs.image-name }}
+        images: |
+          gcr.io/toptal-hub/${{ inputs.image-name }}
+          us-central1-docker.pkg.dev/toptal-hub/containers/${{ inputs.image-name }}
         tags: |
           type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ inputs.sha }}
         flavor: |
           latest=${{ steps.meta-latest.outputs.latest }}
 
-    - name: Login to GCloud Registry
+    - name: Login to Google Container Registry - GCR
       uses: docker/login-action@v2
       with:
         registry: gcr.io
+        username: _json_key
+        password: ${{ env.GCR_ACCOUNT_KEY }}
+
+    - name: Login to Google Artifact Registry - GAR
+      uses: docker/login-action@v2
+      with:
+        registry: us-central1-docker.pkg.dev
         username: _json_key
         password: ${{ env.GCR_ACCOUNT_KEY }}
 


### PR DESCRIPTION
[CI-1579]

### Description
We need to switch from Google Container Registry (GCR) to Google Artifact Registry (GAR) in order to reduce the recent [costs increase](https://cloud.google.com/storage/pricing-announce#network).

In general this is our plan:

First change the jobs that build images to push both to GCR and GAR.
Then go one by one and change the jobs to reference image at GAR.
Once we are sure we covered all, we update building jobs to remove GCR from the list. This is the first step.

### How to test
- run the workflow
- check if the run is successful
- check if the image is in the artifact registry

[CI-1579]: https://toptal-core.atlassian.net/browse/CI-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ