### PR TITLE
chore(deps): add lodash to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "styled-components": "^5.3.5",
     "typescript": "^4.6.4",
     "unified": "^10.1.2"
+  },
+  "resolutions": {
+    "lodash": "^4.17.21"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6248,12 +6248,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
 
-lodash@^3.3.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==
-
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.5.1, lodash@^4.7.0:
+lodash@^3.3.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.5.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
[FX-3262]

### Description

Add `lodash` to resolutions, since vorpal's inner dependencies still use vulnerable version of lodash@3

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
