### PR TITLE
chore: set up node and generate types for deploy storybook

### DIFF
--- a/.changeset/lucky-coats-fly.md
+++ b/.changeset/lucky-coats-fly.md
@@ -1,0 +1,8 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+- add `set up node` step to deploy-storybook
+- create `generate gql types` job

--- a/.changeset/lucky-coats-fly.md
+++ b/.changeset/lucky-coats-fly.md
@@ -4,5 +4,11 @@
 
 ---
 
-- add `set up node` step to deploy-storybook
-- create `generate gql types` job
+### deploy-storybook
+
+- add `set up node` step
+- optional `pr-number` input to be used when `event.number` or `event.issue.number` is not present.
+
+### generate-gql-types
+
+- create new action to generate GQL types

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -10,17 +10,19 @@ Currently ENV variables for Storybook are not supported.
 
 The list of arguments, that are used in GH Action:
 
-| name                   | type                                       | required | default            | description                                                                         |
-| ---------------------- | ------------------------------------------ | -------- | ------------------ | ----------------------------------------------------------------------------------- |
-| `sha`                  | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                         |
-| `environment`          | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                  |
-| `env-file`             | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only |
-| `davinci-branch`       | string                                     |          | master             | Custom davinci branch                                                               |
-| `dist-folder`          | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                             |
-| `build-command`        | string                                     |          | storybook:build    | Command to build Storybook with                                                     |
-| `use-prebuilt-package` | string                                     |          | false              | If a prebuilt Storybook package should be used with                                 |
-| `use-prebuilt-image`   | string                                     |          | false              | If a prebuilt Storybook Docker image should be used with                            |
-| `jenkins-folder-name`  | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                |
+| name                     | type                                       | required | default            | description                                                                         |
+| ------------------------ | ------------------------------------------ | -------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                         |
+| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                  |
+| `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only |
+| `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                               |
+| `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                             |
+| `build-command`          | string                                     |          | storybook:build    | Command to build Storybook with                                                     |
+| `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                      |
+| `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                 |
+| `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                |
+| `generate-types-command` | string                                     |          |                    | Command to generate gql types                                                       |
+| `pr-number`              | string                                     |          |                    | Event number of the original pr                                                     |
 
 ### Outputs
 
@@ -34,7 +36,7 @@ This is a list of ENV Variables that are used in GH Action:
 | name                               | description                                                                           |
 | ---------------------------------- | ------------------------------------------------------------------------------------- |
 | `GITHUB_TOKEN`                     | GitHub token. Is used to checkout `davinci` branch                                    |
-| `GCR_ACCOUNT_KEY`                  | Necessary token to push image to Google cloud\\                                       |
+| `GCR_ACCOUNT_KEY`                  | Necessary token to push image to Google cloud                                         |
 | `GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT` | Necessary token to pull GQL schema from Google Cloud                                  |
 | `JENKINS_DEPLOY_TOKEN`             | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
 | `NPM_TOKEN`                        | Necessary token to install private dependencies                                       |

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -10,19 +10,19 @@ Currently ENV variables for Storybook are not supported.
 
 The list of arguments, that are used in GH Action:
 
-| name                     | type                                       | required | default            | description                                                                         |
-| ------------------------ | ------------------------------------------ | -------- | ------------------ | ----------------------------------------------------------------------------------- |
-| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                         |
-| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                  |
-| `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only |
-| `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                               |
-| `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                             |
-| `build-command`          | string                                     |          | storybook:build    | Command to build Storybook with                                                     |
-| `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                      |
-| `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                 |
-| `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                |
-| `generate-types-command` | string                                     |          |                    | Command to generate gql types                                                       |
-| `pr-number`              | string                                     |          |                    | Event number of the original pr                                                     |
+| name                     | type                                       | required | default            | description                                                                             |
+| ------------------------ | ------------------------------------------ | -------- | ------------------ | --------------------------------------------------------------------------------------- |
+| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                             |
+| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                      |
+| `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only     |
+| `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                                   |
+| `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                                 |
+| `build-command`          | string                                     |          | storybook:build    | Command to build Storybook with                                                         |
+| `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                          |
+| `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                     |
+| `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                    |
+| `generate-types-command` | string                                     |          |                    | Command to generate gql types                                                           |
+| `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. . |
 
 ### Outputs
 
@@ -33,13 +33,13 @@ Not specified
 All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
 This is a list of ENV Variables that are used in GH Action:
 
-| name                               | description                                                                           |
-| ---------------------------------- | ------------------------------------------------------------------------------------- |
-| `GITHUB_TOKEN`                     | GitHub token. Is used to checkout `davinci` branch                                    |
-| `GCR_ACCOUNT_KEY`                  | Necessary token to push image to Google cloud                                         |
-| `GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT` | Necessary token to pull GQL schema from Google Cloud                                  |
-| `JENKINS_DEPLOY_TOKEN`             | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
-| `NPM_TOKEN`                        | Necessary token to install private dependencies                                       |
+| name                             | description                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN`                   | GitHub token. Is used to checkout `davinci` branch                                    |
+| `GCR_ACCOUNT_KEY`                | Necessary token to push image to Google cloud                                         |
+| `GCR_GQL_SCHEMAS_BUCKET_ACCOUNT` | Necessary token to pull GQL schema from Google Cloud                                  |
+| `JENKINS_DEPLOY_TOKEN`           | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
+| `NPM_TOKEN`                      | Necessary token to install private dependencies                                       |
 
 ### Usage
 

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -31,12 +31,13 @@ Not specified
 All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
 This is a list of ENV Variables that are used in GH Action:
 
-| name                   | description                                                                           |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| `GITHUB_TOKEN`         | GitHub token. Is used to checkout `davinci` branch                                    |
-| `GCR_ACCOUNT_KEY`      | Necessary token to push image to Google cloud\\                                       |
-| `JENKINS_DEPLOY_TOKEN` | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
-| `NPM_TOKEN`            | Necessary token to install private dependencies                                       |
+| name                               | description                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN`                     | GitHub token. Is used to checkout `davinci` branch                                    |
+| `GCR_ACCOUNT_KEY`                  | Necessary token to push image to Google cloud\\                                       |
+| `GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT` | Necessary token to pull GQL schema from Google Cloud                                  |
+| `JENKINS_DEPLOY_TOKEN`             | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
+| `NPM_TOKEN`                        | Necessary token to install private dependencies                                       |
 
 ### Usage
 

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -21,7 +21,7 @@ The list of arguments, that are used in GH Action:
 | `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                          |
 | `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                     |
 | `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                    |
-| `generate-types-command` | string                                     |          |                    | Command to generate gql types                                                           |
+| `generate-types-command` | string                                     |          | false              | Command to generate gql types                                                           |
 | `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. . |
 
 ### Outputs
@@ -33,13 +33,13 @@ Not specified
 All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
 This is a list of ENV Variables that are used in GH Action:
 
-| name                             | description                                                                           |
-| -------------------------------- | ------------------------------------------------------------------------------------- |
-| `GITHUB_TOKEN`                   | GitHub token. Is used to checkout `davinci` branch                                    |
-| `GCR_ACCOUNT_KEY`                | Necessary token to push image to Google cloud                                         |
-| `GCR_GQL_SCHEMAS_BUCKET_ACCOUNT` | Necessary token to pull GQL schema from Google Cloud                                  |
-| `JENKINS_DEPLOY_TOKEN`           | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
-| `NPM_TOKEN`                      | Necessary token to install private dependencies                                       |
+| name                           | description                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN`                 | GitHub token. Is used to checkout `davinci` branch                                    |
+| `GCR_ACCOUNT_KEY`              | Necessary token to push image to Google cloud                                         |
+| `GCR_GQL_SCHEMAS_BUCKET_TOKEN` | Necessary token to pull GQL schema from Google Cloud                                  |
+| `JENKINS_DEPLOY_TOKEN`         | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
+| `NPM_TOKEN`                    | Necessary token to install private dependencies                                       |
 
 ### Usage
 

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -36,6 +36,7 @@ This is a list of ENV Variables that are used in GH Action:
 | `GITHUB_TOKEN`         | GitHub token. Is used to checkout `davinci` branch                                    |
 | `GCR_ACCOUNT_KEY`      | Necessary token to push image to Google cloud\\                                       |
 | `JENKINS_DEPLOY_TOKEN` | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
+| `NPM_TOKEN`            | Necessary token to install private dependencies                                       |
 
 ### Usage
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -153,7 +153,7 @@ runs:
         job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
         job_params: |
           {
-            "REPOSITORY_NAME": "temploy",
+            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
             "RELEASE": "${{ env.RELEASE }}",
             "TAG": "${{ inputs.sha }}",
             "ENV": "${{ steps.env-variables.outputs.variables }}"
@@ -170,7 +170,7 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', 'temploy'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -44,6 +44,9 @@ inputs:
   generate-types-command:
     description: Command to generate gql types
     default: false
+  event-number:
+    description: Event number of the original pr
+    default: false
 
 runs:
   using: composite
@@ -51,14 +54,14 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Generate Types
-      if: ${{ inputs.generate-types-command !='false' }}
+      if: ${{ inputs.generate-types-command != false }}
       uses: toptal/davinci-github-actions/generate-gql-types@v3.0.1
       with:
         generate-types-command: ${{ inputs.generate-types-command }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -41,13 +41,27 @@ inputs:
   jenkins-folder-name:
     description: Jenkins folder where the deployment jobs are located
     required: false
+  generate-types-command:
+    description: Command to generate gql types
+    default: false
 
 runs:
   using: composite
   steps:
+    - name: Set up node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 14
+
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
+
+    - name: Generate Types
+      if: ${{ inputs.generate-types-command !='false' }}
+      uses: toptal/davinci-github-actions/generate-gql-types@v3.0.1
+      with:
+        generate-types-command: ${{ inputs.generate-types-command }}
 
     - name: Build Storybook
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -173,4 +173,4 @@ runs:
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ issue_number || ${{ inputs.pr-number }}, owner, repo, body })
+          github.issues.createComment({ ${{ issue_number || inputs.pr-number }}, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -106,7 +106,7 @@ runs:
       if: ${{ inputs.use-prebuilt-image == 'false' }}
       with:
         sha: ${{ inputs.sha }}
-        image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
+        image-name: storybook-release
         build-args: |
           DIST_FOLDER=${{ inputs.dist-folder }}
           NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
@@ -153,7 +153,7 @@ runs:
         job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
         job_params: |
           {
-            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
+            "REPOSITORY_NAME": "storybook",
             "RELEASE": "${{ env.RELEASE }}",
             "TAG": "${{ inputs.sha }}",
             "ENV": "${{ steps.env-variables.outputs.variables }}"
@@ -170,7 +170,7 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', 'storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -5,6 +5,7 @@ description: |
   envInputs:
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
     GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
+    GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT: Necessary token to pull GQL schema from Google Cloud
     JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
     NPM_TOKEN:  Necessary token to install private dependencies 
 
@@ -50,10 +51,6 @@ inputs:
     description: Event number of the original pr
     required: false
     default: false
-  gcr-gqlgw-schemas-bucket-account:
-    description: Necessary token to pull gql schema from google cloud
-    required: false
-    default: false
 
 runs:
   using: composite
@@ -70,8 +67,6 @@ runs:
     - name: Generate Types
       if: ${{ inputs.generate-types-command != false && inputs.gcr-gqlgw-schemas-bucket-account != false }}
       uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
-      env:
-        GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT: ${{ inputs.gcr-gqlgw-schemas-bucket-account }}
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
         gcr-gqlgw-schemas-bucket-account: ${{ env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
@@ -87,6 +82,9 @@ runs:
     - name: Specify Repository, Jenkins folder and Release Name
       id: repo
       shell: bash
+      env:
+        EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
+        ENVIRONMENT: ${{ inputs.environment }}
       run: |
         folder_name=$FOLDER_NAME
 
@@ -96,8 +94,9 @@ runs:
           echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
         fi
 
-        echo repository_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
-        echo release_name=${{ github.event.repository.name }}-pr-${{ github.event.number || github.event.issue.number }}-storybook >> $GITHUB_OUTPUT
+        echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+        echo "release_name=${{ github.event.repository.name }}-pr-${{ env.EVENT_NUMBER }}-${{ env.ENVIRONMENT }}" >> $GITHUB_OUTPUT
+        echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
       env:
         FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
 
@@ -165,7 +164,7 @@ runs:
       uses: actions/github-script@v3.0.0
       env:
         RELEASE: ${{ steps.repo.outputs.release_name }}
-        PR_NUMBER: ${{ inputs.pr-number }}
+        PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Generate Types
       if: ${{ inputs.generate-types-command != 'false' }}
-      uses: toptal/davinci-github-actions/generate-gql-types@4.7.0
+      uses: toptal/davinci-github-actions/generate-gql-types@4.8.0
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
         gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
@@ -170,3 +170,4 @@ runs:
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.issues.createComment({ issue_number: number, owner, repo, body })
+          

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -73,7 +73,6 @@ runs:
 
     - name: Build Storybook
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-      run: yarn "$BUILD_COMMAND"
       shell: bash
       env:
         BUILD_COMMAND: ${{ inputs.build-command }}
@@ -83,6 +82,7 @@ runs:
       id: repo
       shell: bash
       env:
+        FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
         EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
         ENVIRONMENT: ${{ inputs.environment }}
       run: |
@@ -97,9 +97,7 @@ runs:
         echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
         echo "release_name=${{ github.event.repository.name }}-pr-${{ env.EVENT_NUMBER }}-${{ env.ENVIRONMENT }}" >> $GITHUB_OUTPUT
         echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
-      env:
-        FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
-
+        
     - name: Build and Push Storybook Image
       uses: toptal/davinci-github-actions/build-push-image@v4.4.2
       if: ${{ inputs.use-prebuilt-image == 'false' }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -167,10 +167,11 @@ runs:
       uses: actions/github-script@v3.0.0
       env:
         RELEASE: ${{ steps.repo.outputs.release_name }}
+        ISSUE_NUMBER: ${{ issue_number || inputs.pr-number }}
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ issue_number || inputs.pr-number, owner, repo, body })
+          github.issues.createComment({ env.ISSUE_NUMBER, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -6,6 +6,7 @@ description: |
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
     GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
     JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
+    NPM_TOKEN:  Necessary token to install private dependencies 
 
 inputs:
   sha:

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -167,11 +167,12 @@ runs:
       uses: actions/github-script@v3.0.0
       env:
         RELEASE: ${{ steps.repo.outputs.release_name }}
+        PR_NUMBER: ${{ inputs.pr-number }}
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          const issuenumber = issue_number || ${{ inputs.pr-number }}
-          github.issues.createComment({ issuenumber, owner, repo, body })
+          const number = issue_number || ${{ env.PR_NUMBER }}
+          github.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -5,7 +5,7 @@ description: |
   envInputs:
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
     GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
-    GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT: Necessary token to pull GQL schema from Google Cloud
+    GCR_GQL_SCHEMAS_BUCKET_ACCOUNT: Necessary token to pull GQL schema from Google Cloud
     JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
     NPM_TOKEN:  Necessary token to install private dependencies 
 
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: false
   pr-number:
-    description: Event number of the original pr
+    description: Event number of the original pr, in case event number or issue number is not present. .
     required: false
     default: false
 
@@ -65,11 +65,11 @@ runs:
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Generate Types
-      if: ${{ inputs.generate-types-command != false && env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT != false }}
+      if: ${{ inputs.generate-types-command != false && env.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT != false }}
       uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
-        gcr-gqlgw-schemas-bucket-account: ${{ env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+        gcr-gql-schemas-bucket-account: ${{ env.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT }}
 
     - name: Build Storybook
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
@@ -84,7 +84,6 @@ runs:
       env:
         FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
         EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
-        ENVIRONMENT: ${{ inputs.environment }}
       run: |
         folder_name=$FOLDER_NAME
 
@@ -95,7 +94,7 @@ runs:
         fi
 
         echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-        echo "release_name=${{ github.event.repository.name }}-pr-${{ env.EVENT_NUMBER }}-${{ env.ENVIRONMENT }}" >> $GITHUB_OUTPUT
+        echo "release_name=${{ github.event.repository.name }}-pr-$EVENT_NUMBER-storybook" >> $GITHUB_OUTPUT
         echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
         
     - name: Build and Push Storybook Image
@@ -103,7 +102,7 @@ runs:
       if: ${{ inputs.use-prebuilt-image == 'false' }}
       with:
         sha: ${{ inputs.sha }}
-        image-name: storybook-release
+        image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
         build-args: |
           DIST_FOLDER=${{ inputs.dist-folder }}
           NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
@@ -150,7 +149,7 @@ runs:
         job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
         job_params: |
           {
-            "REPOSITORY_NAME": "storybook",
+            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
             "RELEASE": "${{ env.RELEASE }}",
             "TAG": "${{ inputs.sha }}",
             "ENV": "${{ steps.env-variables.outputs.variables }}"
@@ -167,7 +166,7 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', 'storybook'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -46,7 +46,7 @@ inputs:
     description: Command to generate gql types
     required: false
     default: false
-  event-number:
+  pr-number:
     description: Event number of the original pr
     required: false
     default: false
@@ -61,7 +61,7 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 14
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
@@ -82,7 +82,6 @@ runs:
       shell: bash
       env:
         BUILD_COMMAND: ${{ inputs.build-command }}
-        NODE_OPTIONS: "--max_old_space_size=8192"
       run: yarn "$BUILD_COMMAND"
 
     - name: Specify Repository, Jenkins folder and Release Name

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -87,8 +87,6 @@ runs:
     - name: Specify Repository, Jenkins folder and Release Name
       id: repo
       shell: bash
-      env:
-        RELEASE_SUFFIX: ${{ inputs.environment == 'temploy' && 'storybook-temploy' || 'storybook' }}
       run: |
         folder_name=$FOLDER_NAME
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -88,7 +88,7 @@ runs:
       id: repo
       shell: bash
       env:
-        RELEASE_SUFFIX: ${{ inputs.environment == 'temploy' }} && 'storybook-temploy' || 'storybook'
+        RELEASE_SUFFIX: ${{ inputs.environment == 'temploy' && 'storybook-temploy' || 'storybook' }}
       run: |
         folder_name=$FOLDER_NAME
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -173,4 +173,5 @@ runs:
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ ${{ issue_number || inputs.pr-number }}, owner, repo, body })
+          const issuenumber = issue_number || ${{ inputs.pr-number }}
+          github.issues.createComment({ issuenumber, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Generate Types
       if: ${{ inputs.generate-types-command != 'false' }}
-      uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
+      uses: toptal/davinci-github-actions/generate-gql-types@4.7.0
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
         gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -167,11 +167,10 @@ runs:
       uses: actions/github-script@v3.0.0
       env:
         RELEASE: ${{ steps.repo.outputs.release_name }}
-        ISSUE_NUMBER: ${{ issue_number || inputs.pr-number }}
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ env.ISSUE_NUMBER, owner, repo, body })
+          github.issues.createComment({ ${{ issue_number || inputs.pr-number }}, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -43,9 +43,15 @@ inputs:
     required: false
   generate-types-command:
     description: Command to generate gql types
+    required: false
     default: false
   event-number:
     description: Event number of the original pr
+    required: false
+    default: false
+  gcr-gqlgw-schemas-bucket-account:
+    description: Necessary token to pull gql schema from google cloud
+    required: false
     default: false
 
 runs:
@@ -61,10 +67,13 @@ runs:
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Generate Types
-      if: ${{ inputs.generate-types-command != false }}
-      uses: toptal/davinci-github-actions/generate-gql-types@v3.0.1
+      if: ${{ inputs.generate-types-command != false && inputs.gcr-gqlgw-schemas-bucket-account != false }}
+      uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
+      env:
+        GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT: ${{ inputs.gcr-gqlgw-schemas-bucket-account }}
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
+        gcr-gqlgw-schemas-bucket-account: ${{ env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
 
     - name: Build Storybook
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -65,7 +65,7 @@ runs:
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Generate Types
-      if: ${{ inputs.generate-types-command != false && inputs.gcr-gqlgw-schemas-bucket-account != false }}
+      if: ${{ inputs.generate-types-command != false && env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT != false }}
       uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
       with:
         generate-types-command: ${{ inputs.generate-types-command }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -87,6 +87,8 @@ runs:
     - name: Specify Repository, Jenkins folder and Release Name
       id: repo
       shell: bash
+      env:
+        RELEASE_SUFFIX: ${{ inputs.environment == 'temploy' }} && 'storybook-temploy' || 'storybook'
       run: |
         folder_name=$FOLDER_NAME
 
@@ -171,4 +173,4 @@ runs:
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ issue_number, owner, repo, body })
+          github.issues.createComment({ issue_number || inputs.pr-number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -5,7 +5,7 @@ description: |
   envInputs:
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
     GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
-    GCR_GQL_SCHEMAS_BUCKET_ACCOUNT: Necessary token to pull GQL schema from Google Cloud
+    GCR_GQL_SCHEMAS_BUCKET_TOKEN: Necessary token to pull GQL schema from Google Cloud
     JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
     NPM_TOKEN:  Necessary token to install private dependencies 
 
@@ -46,7 +46,7 @@ inputs:
   generate-types-command:
     description: Command to generate gql types
     required: false
-    default: false
+    default: 'false'
   pr-number:
     description: Event number of the original pr, in case event number or issue number is not present. .
     required: false
@@ -65,11 +65,11 @@ runs:
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Generate Types
-      if: ${{ inputs.generate-types-command != false && env.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT != false }}
+      if: ${{ inputs.generate-types-command != 'false' }}
       uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
-        gcr-gql-schemas-bucket-account: ${{ env.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT }}
+        gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
 
     - name: Build Storybook
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -170,7 +170,7 @@ runs:
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
-          const { issue: { number: issue_number }, repo: { owner, repo }  } = context
+          const { issue: { number: issue_number || inputs.pr-number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ ${{ issue_number || inputs.pr-number }}, owner, repo, body })
+          github.issues.createComment({ issue_number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -153,7 +153,7 @@ runs:
         job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
         job_params: |
           {
-            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
+            "REPOSITORY_NAME": "temploy",
             "RELEASE": "${{ env.RELEASE }}",
             "TAG": "${{ inputs.sha }}",
             "ENV": "${{ steps.env-variables.outputs.variables }}"
@@ -170,7 +170,7 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', 'temploy'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -170,7 +170,7 @@ runs:
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
-          const { issue: { number: issue_number || inputs.pr-number }, repo: { owner, repo }  } = context
+          const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ issue_number, owner, repo, body })
+          github.issues.createComment({ issue_number || '${{ inputs.pr-number }}', owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -82,6 +82,8 @@ runs:
       shell: bash
       env:
         BUILD_COMMAND: ${{ inputs.build-command }}
+        NODE_OPTIONS: "--max_old_space_size=8192"
+      run: yarn "$BUILD_COMMAND"
 
     - name: Specify Repository, Jenkins folder and Release Name
       id: repo

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -173,4 +173,4 @@ runs:
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          github.issues.createComment({ issue_number || '${{ inputs.pr-number }}', owner, repo, body })
+          github.issues.createComment({ issue_number || ${{ inputs.pr-number }}, owner, repo, body })

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -8,10 +8,10 @@ Generate graphql types before application build
 
 The list of arguments, that are used in GH Action:
 
-| name                             | type   | required | default        | description                                          |
-| -------------------------------- | ------ | -------- | -------------- | ---------------------------------------------------- |
-| `generate-types-command`         | string |          | generate:types | Command to generate gql types                        |
-| `gcr-gql-schemas-bucket-account` | string | ✅        |                | Necessary token to pull gql schema from google cloud |
+| name                           | type   | required | default        | description                                          |
+| ------------------------------ | ------ | -------- | -------------- | ---------------------------------------------------- |
+| `generate-types-command`       | string |          | generate:types | Command to generate gql types                        |
+| `gcr-gql-schemas-bucket-token` | string | ✅        |                | Necessary token to pull gql schema from google cloud |
 
 ### Outputs
 
@@ -27,6 +27,7 @@ Not specified
   - uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
     env:
       GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
+      GCR_GQL_SCHEMAS_BUCKET_TOKEN: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
     with:
       generate-types-command: generate:types
       gcr-gql-schemas-bucket-account: ${{ secrets.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT }}

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -22,3 +22,12 @@ Not specified
 Not specified
 
 ### Usage
+
+```yaml
+  - uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
+    env:
+      GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
+    with:
+      generate-types-command: generate:types
+      gcr-gqlgw-schemas-bucket-account: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+```

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -1,0 +1,23 @@
+## Generate GQL Types
+
+Generate graphql types before application build
+
+### Description
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name                     | type   | required | default        | description                   |
+| ------------------------ | ------ | -------- | -------------- | ----------------------------- |
+| `generate-types-command` | string |          | generate:types | Command to generate gql types |
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+Not specified
+
+### Usage

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -24,7 +24,7 @@ Not specified
 ### Usage
 
 ```yaml
-  - uses: toptal/davinci-github-actions/generate-gql-types@CPT-420-temploy-storybook-staff-portal
+  - uses: toptal/davinci-github-actions/generate-gql-types@4.7.0
     env:
       GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
       GCR_GQL_SCHEMAS_BUCKET_TOKEN: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -8,10 +8,10 @@ Generate graphql types before application build
 
 The list of arguments, that are used in GH Action:
 
-| name                               | type   | required | default        | description                                          |
-| ---------------------------------- | ------ | -------- | -------------- | ---------------------------------------------------- |
-| `generate-types-command`           | string |          | generate:types | Command to generate gql types                        |
-| `gcr-gqlgw-schemas-bucket-account` | string | ✅        |                | Necessary token to pull gql schema from google cloud |
+| name                             | type   | required | default        | description                                          |
+| -------------------------------- | ------ | -------- | -------------- | ---------------------------------------------------- |
+| `generate-types-command`         | string |          | generate:types | Command to generate gql types                        |
+| `gcr-gql-schemas-bucket-account` | string | ✅        |                | Necessary token to pull gql schema from google cloud |
 
 ### Outputs
 
@@ -29,5 +29,5 @@ Not specified
       GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
     with:
       generate-types-command: generate:types
-      gcr-gqlgw-schemas-bucket-account: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+      gcr-gql-schemas-bucket-account: ${{ secrets.GCR_GQL_SCHEMAS_BUCKET_ACCOUNT }}
 ```

--- a/generate-gql-types/README.md
+++ b/generate-gql-types/README.md
@@ -8,9 +8,10 @@ Generate graphql types before application build
 
 The list of arguments, that are used in GH Action:
 
-| name                     | type   | required | default        | description                   |
-| ------------------------ | ------ | -------- | -------------- | ----------------------------- |
-| `generate-types-command` | string |          | generate:types | Command to generate gql types |
+| name                               | type   | required | default        | description                                          |
+| ---------------------------------- | ------ | -------- | -------------- | ---------------------------------------------------- |
+| `generate-types-command`           | string |          | generate:types | Command to generate gql types                        |
+| `gcr-gqlgw-schemas-bucket-account` | string | ✅        |                | Necessary token to pull gql schema from google cloud |
 
 ### Outputs
 

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -5,7 +5,7 @@ inputs:
   generate-types-command:
     description: Command to generate gql types
     default: generate:types
-  gcr-gql-schemas-bucket-account: 
+  gcr-gql-schemas-bucket-token: 
     description: Necessary token to pull gql schema from google cloud
     required: true
 
@@ -15,7 +15,7 @@ runs:
     - name: Auth Google cloud toolchain
       uses: google-github-actions/auth@v1.0.0
       with:
-        credentials_json: ${{ inputs.gcr-gql-schemas-bucket-account }}
+        credentials_json: ${{ inputs.gcr-gql-schemas-bucket-token }}
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -11,14 +11,11 @@ runs:
     - name: Auth Google cloud toolchain
       uses: google-github-actions/auth@v1.0.0
       with:
-        credentials_json: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+        credentials_json: ${{ env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain
       uses: google-github-actions/setup-gcloud@v0.6.0
-
-    - name: Fetch gql schemas
-      run: yarn fetch:graphql-schemas
 
     - name: Check types cache
       uses: actions/cache@v3
@@ -31,4 +28,6 @@ runs:
 
     - name: Generate types
       if: ${{ steps.storybook-gql-types-cache.outputs.cache-hit != 'true' }}
-      run: yarn ${{ inputs.generate-types-command }}
+      env:
+        COMMAND: ${{ inputs.generate-types-command }}
+      run: yarn $COMMAND

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -1,9 +1,13 @@
 name: Generate GQL Types
 description: Generate graphql types before application build
+    
 inputs:
   generate-types-command:
     description: Command to generate gql types
     default: generate:types
+  gcr-gqlgw-schemas-bucket-account: 
+    description: Necessary token to pull gql schema from google cloud
+    required: true
 
 runs:
   using: composite
@@ -11,7 +15,7 @@ runs:
     - name: Auth Google cloud toolchain
       uses: google-github-actions/auth@v1.0.0
       with:
-        credentials_json: ${{ env.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+        credentials_json: ${{ inputs.gcr-gqlgw-schemas-bucket-account }}
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -5,7 +5,7 @@ inputs:
   generate-types-command:
     description: Command to generate gql types
     default: generate:types
-  gcr-gqlgw-schemas-bucket-account: 
+  gcr-gql-schemas-bucket-account: 
     description: Necessary token to pull gql schema from google cloud
     required: true
 
@@ -15,7 +15,7 @@ runs:
     - name: Auth Google cloud toolchain
       uses: google-github-actions/auth@v1.0.0
       with:
-        credentials_json: ${{ inputs.gcr-gqlgw-schemas-bucket-account }}
+        credentials_json: ${{ inputs.gcr-gql-schemas-bucket-account }}
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain
@@ -23,7 +23,7 @@ runs:
 
     - name: Check types cache
       uses: actions/cache@v3
-      id: storybook-gql-types-cache
+      id: gql-types-cache
       with:
         path: |
           libs/graphql
@@ -31,7 +31,7 @@ runs:
         key: ${{ runner.os }}-types-${{ hashFiles('yarn.lock', '**/codegen.js', '**/*.graphql', '**/*.graphql.ts', '**/*.gql.ts') }}
 
     - name: Generate types
-      if: ${{ steps.storybook-gql-types-cache.outputs.cache-hit != 'true' }}
+      if: ${{ steps.gql-types-cache.outputs.cache-hit != 'true' }}
       shell: bash
       env:
         COMMAND: ${{ inputs.generate-types-command }}

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -32,6 +32,7 @@ runs:
 
     - name: Generate types
       if: ${{ steps.storybook-gql-types-cache.outputs.cache-hit != 'true' }}
+      shell: bash
       env:
         COMMAND: ${{ inputs.generate-types-command }}
       run: yarn $COMMAND

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -1,0 +1,34 @@
+name: Generate GQL Types
+description: Generate graphql types before application build
+inputs:
+  generate-types-command:
+    description: Command to generate gql types
+    default: generate:types
+
+runs:
+  using: composite
+  steps:
+    - name: Auth Google cloud toolchain
+      uses: google-github-actions/auth@v1.0.0
+      with:
+        credentials_json: ${{ secrets.GCR_GQLGW_SCHEMAS_BUCKET_ACCOUNT }}
+        create_credentials_file: true
+
+    - name: Setup Google cloud toolchain
+      uses: google-github-actions/setup-gcloud@v0.6.0
+
+    - name: Fetch gql schemas
+      run: yarn fetch:graphql-schemas
+
+    - name: Check types cache
+      uses: actions/cache@v3
+      id: storybook-gql-types-cache
+      with:
+        path: |
+          libs/graphql
+          **/*.types.tsx
+        key: ${{ runner.os }}-types-${{ hashFiles('yarn.lock', '**/codegen.js', '**/*.graphql', '**/*.graphql.ts', '**/*.gql.ts') }}
+
+    - name: Generate types
+      if: ${{ steps.storybook-gql-types-cache.outputs.cache-hit != 'true' }}
+      run: yarn ${{ inputs.generate-types-command }}


### PR DESCRIPTION
[CPT-420](https://toptal-core.atlassian.net/browse/CPT-420)

### Description

`Set up node` for deploy-storybook action and add an optional `generate  gql types` action which will be used by staff -portal in the first place.

### How Workflow Works
When we comment `@toptal-bot run storybook-temploy` on a PR in staff-portal, [PR Comments](https://github.com/toptal/staff-portal/blob/884aef6e5ee0402bb0d096182138efeabfa61c28/.github/workflows/pr_job_comment.yml#L104) gets triggered and runs [Deploy Storybook to temploy](https://github.com/toptal/staff-portal/blob/46906034d031a49e89d5e04bd69909cc1619e4eb/.github/workflows/storybook_temploy_on_pr_comment.yml). And this job runs [Deploy Storybook to a particular environment](https://github.com/toptal/davinci-github-actions/blob/077a5ce65b3b1ada468957a2943bb433f1a7717b/deploy-storybook/action.yml) updated here in this PR.


### How to test

(These changes are currently in test)
- Go to the PR's in staff portal: [https://github.com/toptal/staff-portal/pull/9292](https://github.com/toptal/staff-portal/pull/9292)
- Comment `@toptal-bot run storybook-temploy` on PR
- Comment must trigger  `deploy-storybook` action in this repo
- When successful, it must comment temploy url to PR

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
