### PR TITLE
chore: add auto bundling

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,11 @@ module.exports = {
     paths.length > 0
       ? ['yarn documentation:generate', `git add */README.md`]
       : [],
-  'get-changeset-info/index.js': () => [
+  'create-matrix/**/*.js': () => [
+    'yarn build:create-matrix',
+    'git add create-matrix/dist',
+  ],
+  'get-changeset-info/**/*.js': () => [
     'yarn build:get-changeset-info',
     'git add get-changeset-info/dist',
   ],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "davinci-qa unit --runInBand",
     "test:ci": "LANG=en_US davinci-qa unit --ci --testTimeout=10000 --silent",
     "prepare": "husky install",
-    "build:matrix": "ncc build create-matrix/index.js -o create-matrix/dist",
+    "build:create-matrix": "ncc build create-matrix/index.js -o create-matrix/dist",
     "build:get-changeset-info": "ncc build get-changeset-info/index.js -o get-changeset-info/dist",
     "build:report-missing-changeset": "ncc build report-missing-changeset/index.js -o report-missing-changeset/dist"
   },


### PR DESCRIPTION
### Description

Add `create-matrix` action to lintstaged to run automatic bundling on change.

CONTEXT: When working with js actions, devs may forget to bundle after changing the code. 

### How to test

- you can try to make some change in `create-matrix/index.js` and on commit you should see auto-bundling the code

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
