### PR TITLE
[GE-630] Adjust deploy-storybook for Frontier usage

### DIFF
--- a/.changeset/pretty-llamas-sort.md
+++ b/.changeset/pretty-llamas-sort.md
@@ -1,0 +1,15 @@
+---
+"davinci-github-actions": minor
+---
+
+---
+
+### deploy-storybook
+
+- adjust action to support usage on frontier-pub
+- add `use-prebuilt-package`, `use-prebuilt-image` and `jenkins-folder-name` inputs
+- fix `set-output` warnings
+
+### yarn-install
+
+- fix `set-output` warnings

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -10,14 +10,17 @@ Currently ENV variables for Storybook are not supported.
 
 The list of arguments, that are used in GH Action:
 
-| name             | type                                       | required | default            | description                                                                         |
-| ---------------- | ------------------------------------------ | -------- | ------------------ | ----------------------------------------------------------------------------------- |
-| `sha`            | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                         |
-| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                  |
-| `env-file`       | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only |
-| `davinci-branch` | string                                     |          | master             | Custom davinci branch                                                               |
-| `dist-folder`    | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                             |
-| `build-command`  | string                                     |          | storybook:build    | Command to build Storybook with                                                     |
+| name                   | type                                       | required | default            | description                                                                         |
+| ---------------------- | ------------------------------------------ | -------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `sha`                  | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                         |
+| `environment`          | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                  |
+| `env-file`             | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only |
+| `davinci-branch`       | string                                     |          | master             | Custom davinci branch                                                               |
+| `dist-folder`          | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                             |
+| `build-command`        | string                                     |          | storybook:build    | Command to build Storybook with                                                     |
+| `use-prebuilt-package` | string                                     |          | false              | If a prebuilt Storybook package should be used with                                 |
+| `use-prebuilt-image`   | string                                     |          | false              | If a prebuilt Storybook Docker image should be used with                            |
+| `jenkins-folder-name`  | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                |
 
 ### Outputs
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -4,7 +4,7 @@ description: |
   ****
   envInputs:
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
-    GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud\
+    GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
     JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
 
 inputs:
@@ -30,28 +30,52 @@ inputs:
     description: Command to build Storybook with
     required: false
     default: storybook:build
+  use-prebuilt-package:
+    description: If a prebuilt Storybook package should be used
+    required: false
+    default: 'false'
+  use-prebuilt-image:
+    description: If a prebuilt Storybook Docker image should be used
+    required: false
+    default: 'false'
+  jenkins-folder-name:
+    description: Jenkins folder where the deployment jobs are located
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Install Dependencies
+      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
       uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
     - name: Build Storybook
+      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
+      run: yarn "$BUILD_COMMAND"
       shell: bash
       env:
         BUILD_COMMAND: ${{ inputs.build-command }}
-      run: yarn "$BUILD_COMMAND"
 
-    - name: Specify Repository and Release Name
+    - name: Specify Repository, Jenkins folder and Release Name
       id: repo
       shell: bash
       run: |
-        echo ::set-output name=repository_name::${{ github.event.repository.name }}
-        echo ::set-output name=release_name::${{ github.event.repository.name }}-pr-${{ github.event.number || github.event.issue.number }}-storybook
+        folder_name=$FOLDER_NAME
+
+        if [[ "$folder_name" == '' ]]; then
+          echo folder_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
+        else
+          echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
+        fi
+
+        echo repository_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
+        echo release_name=${{ github.event.repository.name }}-pr-${{ github.event.number || github.event.issue.number }}-storybook >> $GITHUB_OUTPUT
+      env:
+        FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
 
     - name: Build and Push Storybook Image
       uses: toptal/davinci-github-actions/build-push-image@v4.4.2
+      if: ${{ inputs.use-prebuilt-image == 'false' }}
       with:
         sha: ${{ inputs.sha }}
         image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
@@ -67,12 +91,13 @@ runs:
       if: ${{ inputs.environment == 'staging' }}
       uses: toptal/jenkins-job-trigger-action@1.0.0
       env:
+        JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
       with:
         jenkins_url: https://jenkins.toptal.net
         jenkins_user: toptal-devbot
         jenkins_token: ${{ env.JENKINS_DEPLOY_TOKEN }}
-        job_name: ${{ env.REPOSITORY_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
+        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
         job_params: |
           {
             "TAG": "${{ inputs.sha }}"
@@ -90,13 +115,14 @@ runs:
       if: ${{ inputs.environment == 'temploy' }}
       uses: toptal/jenkins-job-trigger-action@1.0.0
       env:
+        JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
         RELEASE: ${{ steps.repo.outputs.release_name }}
       with:
         jenkins_url: https://jenkins-build.toptal.net/
         jenkins_user: toptal-jenkins
         jenkins_token: ${{ env.JENKINS_DEPLOY_TOKEN }}
-        job_name: ${{ env.REPOSITORY_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
+        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
         job_params: |
           {
             "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -21,12 +21,12 @@ runs:
   steps:
     - name: Set node version
       id: set-node-version
+      run: echo version=$(node -v) >> $GITHUB_OUTPUT
       shell: bash
-      run: echo "::set-output name=version::$(node -v)"
 
     - name: Get yarn cache
       id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo dir=$(yarn cache dir) >> $GITHUB_OUTPUT
       shell: bash
 
     # This step is needed only because we want to update the cache when a new workspace


### PR DESCRIPTION
[GE-630]

### Description

Extending `deploy-storybook` action to support deployments for frontier-pub project, from the Growth Squad. To optimize the process, I've added a couple of options to enable using an existing Storybook package or an existing Docker image, avoiding the need of building the package/image twice. Also, an option to be able to set a custom folder name on Jenkins, since all of our jobs are on a `Frontier` folder, which does not match the repository name.

Finally, fixing `set-output` warnings from `deploy-storybook` and `yarn-install` actions, since that [will be deprecated soon](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

- Changes were tested in the Jenkins jobs:
  - [Temploy](https://jenkins-build.toptal.net/job/Frontier/job/frontier-pub-storybook-temploy-helm-run/)
  - [Staging](https://jenkins.toptal.net/job/Frontier/job/frontier-pub-storybook-staging-deployment/)
- Applications available on [Temploy](https://frontier-pub-pr-4241-storybook-frontier-pub-s.toptal.rocks/) and [Staging](https://frontier-storybook-staging.toptal.net/)
- Related frontier-pub PR: https://github.com/toptal/frontier-pub/pull/4255
- Related inf-helm PR for Staging setup: https://github.com/toptal/inf-helm/pull/2060

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[GE-630]: https://toptal-core.atlassian.net/browse/GE-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ