### PR TITLE
chore: fix version number typo

### DIFF
--- a/.changeset/gentle-donuts-perform.md
+++ b/.changeset/gentle-donuts-perform.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- fix version number typo used inside `deploy-storybook` action

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Generate Types
       if: ${{ inputs.generate-types-command != 'false' }}
-      uses: toptal/davinci-github-actions/generate-gql-types@4.8.0
+      uses: toptal/davinci-github-actions/generate-gql-types@v4.8.1
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
         gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}


### PR DESCRIPTION
[no jira]

### Description

Version number of `generate-gql-types` is not correctly formed. Added missing `v` to fix.

### How to test

- Workflow must run correctly.

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
