### PR TITLE
[SE-2725] Updating deprecated GitHub commands for build-push-image

### DIFF
--- a/.changeset/few-roses-hug.md
+++ b/.changeset/few-roses-hug.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- updating set-output command and checkout action version for build-push-image package

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Checkout davinci
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: toptal/davinci
         token: ${{ env.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
       run: |
         latest=$(if [[ $ENVIRONMENT == 'temploy' ]]; then echo false; else echo true; fi)
-        echo "::set-output name=latest::$latest"
+        echo latest=$latest >> $GITHUB_OUTPUT
 
     - name: Docker meta
       id: meta

--- a/create-matrix/README.md
+++ b/create-matrix/README.md
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Matrix
         id: set-matrix


### PR DESCRIPTION
[SE-2725]

### Description

Updating deprecated GitHub commands for `build-push-image`
- set-output
- actions/checkout version

### How to test

- Tested using this commit as reference on this [PR](https://github.com/toptal/frontier-pub/pull/3970/commits/d90b4d3352ea1c617aab70da88559344bb87f920#diff-97cca8fb169bc3951469886bf2f73b7bcc362a6b6da11325c7a617f69a797248), fixed all warnings on our [workflow](https://github.com/toptal/frontier-pub/actions/runs/3796023309/jobs/6455726443).

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[SE-2725]: https://toptal-core.atlassian.net/browse/SE-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ