### PR TITLE
[SE-2725] Fixing GHA deprecated commands for deploy-storybook package

### DIFF
--- a/.changeset/shy-rocks-talk.md
+++ b/.changeset/shy-rocks-talk.md
@@ -1,0 +1,11 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- updating docker/metadata-action action version for build-push-image package
+- updating internal packages for build-push-release-image and deploy-storybook packages
+- updating jenkins-job-trigger-action and actions/github-script action version for deploy-storybook package
+- updating actions/github-script action version for extract-env-variables package
+- updating google-github-actions/setup-gcloud action version for generate-gql-types package

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4.0.1
+      uses: docker/metadata-action@v4.1.1
       with:
         images: |
           gcr.io/toptal-hub/${{ inputs.image-name }}

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -21,13 +21,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: toptal/davinci-github-actions/yarn-install@v4.4.2
+    - uses: toptal/davinci-github-actions/yarn-install@v4.8.2
 
     - name: Build
       shell: bash
       run: yarn build
 
-    - uses: toptal/davinci-github-actions/build-push-image@v4.4.2
+    - uses: toptal/davinci-github-actions/build-push-image@v4.8.2
       with:
         sha: ${{ inputs.sha }}
         image-name: ${{ inputs.repository-name }}-release

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -62,11 +62,11 @@ runs:
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-      uses: toptal/davinci-github-actions/yarn-install@v4.4.2
+      uses: toptal/davinci-github-actions/yarn-install@v4.8.2
 
     - name: Generate Types
       if: ${{ inputs.generate-types-command != 'false' }}
-      uses: toptal/davinci-github-actions/generate-gql-types@v4.8.1
+      uses: toptal/davinci-github-actions/generate-gql-types@v4.8.2
       with:
         generate-types-command: ${{ inputs.generate-types-command }}
         gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
@@ -98,7 +98,7 @@ runs:
         echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
         
     - name: Build and Push Storybook Image
-      uses: toptal/davinci-github-actions/build-push-image@v4.4.2
+      uses: toptal/davinci-github-actions/build-push-image@v4.8.2
       if: ${{ inputs.use-prebuilt-image == 'false' }}
       with:
         sha: ${{ inputs.sha }}
@@ -113,7 +113,7 @@ runs:
 
     - name: Trigger Deploy to Staging
       if: ${{ inputs.environment == 'staging' }}
-      uses: toptal/jenkins-job-trigger-action@1.0.0
+      uses: toptal/jenkins-job-trigger-action@1.0.1
       env:
         JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
@@ -128,7 +128,7 @@ runs:
           }
         job_timeout: 1200
 
-    - uses: toptal/davinci-github-actions/extract-env-variables@v4.4.2
+    - uses: toptal/davinci-github-actions/extract-env-variables@v4.8.3
       if: ${{ inputs.environment == 'temploy' }}
       id: env-variables
       with:
@@ -137,7 +137,7 @@ runs:
 
     - name: Trigger Deploy to Temploy
       if: ${{ inputs.environment == 'temploy' }}
-      uses: toptal/jenkins-job-trigger-action@1.0.0
+      uses: toptal/jenkins-job-trigger-action@1.0.1
       env:
         JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
@@ -158,7 +158,7 @@ runs:
 
     - name: Post Temploy Link
       if: ${{ inputs.environment == 'temploy' }}
-      uses: actions/github-script@v3.0.0
+      uses: actions/github-script@v6.3.3
       env:
         RELEASE: ${{ steps.repo.outputs.release_name }}
         PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
@@ -169,5 +169,4 @@ runs:
           const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
-          github.issues.createComment({ issue_number: number, owner, repo, body })
-          
+          github.rest.issues.createComment({ issue_number: number, owner, repo, body })

--- a/extract-env-variables/action.yml
+++ b/extract-env-variables/action.yml
@@ -16,9 +16,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Exctract Env variables
+    - name: Extract Env variables
       id: env-variables
-      uses: actions/github-script@v3.0.0
+      uses: actions/github-script@v6.3.3
       with:
         github-token: ${{ inputs.github-token }}
         result-encoding: string

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -19,7 +19,7 @@ runs:
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain
-      uses: google-github-actions/setup-gcloud@v0.6.0
+      uses: google-github-actions/setup-gcloud@v1.0.1
 
     - name: Check types cache
       uses: actions/cache@v3


### PR DESCRIPTION
[SE-2725] [GE-637]

### Description

- updating `docker/metadata-action` action version for `build-push-image package`
- updating internal packages for `build-push-release-image` and `deploy-storybook packages`
- updating `jenkins-job-trigger-action` and `actions/github-script` action version for `deploy-storybook` package
- updating `actions/github-script` action version for `extract-env-variables` package
- updating `google-github-actions/setup-gcloud` action version for `generate-gql-types` package

### How to test

- Tested first commit as internal reference 
- Tested second commit as external reference https://github.com/toptal/frontier-pub/pull/3970/commits/45d956b17c9b3076ca33c87e61685afa60887104

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[SE-2725]: https://toptal-core.atlassian.net/browse/SE-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GE-637]: https://toptal-core.atlassian.net/browse/GE-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ