### PR TITLE
Bump version build push release image

### DIFF
--- a/.changeset/famous-apricots-live.md
+++ b/.changeset/famous-apricots-live.md
@@ -4,4 +4,6 @@
 
 ---
 
-- updating internal packages for build-push-release-image
+### build-push-release-image
+
+- bump yarn-install action to newer version

--- a/.changeset/famous-apricots-live.md
+++ b/.changeset/famous-apricots-live.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- updating internal packages for build-push-release-image

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: yarn build
 
-    - uses: toptal/davinci-github-actions/build-push-image@v4.8.3
+    - uses: toptal/davinci-github-actions/build-push-image@v4.8.4
       with:
         sha: ${{ inputs.sha }}
         image-name: ${{ inputs.repository-name }}-release

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -21,13 +21,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: toptal/davinci-github-actions/yarn-install@v4.8.2
+    - uses: toptal/davinci-github-actions/yarn-install@v4.8.3
 
     - name: Build
       shell: bash
       run: yarn build
 
-    - uses: toptal/davinci-github-actions/build-push-image@v4.8.4
+    - uses: toptal/davinci-github-actions/build-push-image@v4.8.3
       with:
         sha: ${{ inputs.sha }}
         image-name: ${{ inputs.repository-name }}-release


### PR DESCRIPTION
[GE-663](https://toptal-core.atlassian.net/browse/GE-663)

### Description

To fix the warning on Blackfish-Frontend project, we updated the `build-push-release-image` job..

### How to test

- Tested through [this PR](https://github.com/toptal/blackfish-frontend/pull/822)
### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[GE-663]: https://toptal-core.atlassian.net/browse/GE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ