### PR TITLE
Address deprecated commands

### DIFF
--- a/.changeset/green-papayas-stare.md
+++ b/.changeset/green-papayas-stare.md
@@ -1,0 +1,13 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### build-push-release-image
+
+- bump yarn-install action to latest version
+
+### get-workflow-sha
+
+- address deprecated commands

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: toptal/davinci-github-actions/yarn-install@v4.8.3
+    - uses: toptal/davinci-github-actions/yarn-install@v4.8.5
 
     - name: Build
       shell: bash

--- a/get-workflow-sha/action.yml
+++ b/get-workflow-sha/action.yml
@@ -26,4 +26,4 @@ runs:
         VERSION: ${{ github.event.inputs.version }}
         SHA: ${{ github.sha }}
       run: |
-        echo "::set-output name=sha::${HEAD_SHA:-${VERSION:-${SHA}}}"
+        echo echo "sha=${HEAD_SHA:-${VERSION:-${SHA}}}" >> $GITHUB_OUTPUT

--- a/get-workflow-sha/action.yml
+++ b/get-workflow-sha/action.yml
@@ -26,4 +26,4 @@ runs:
         VERSION: ${{ github.event.inputs.version }}
         SHA: ${{ github.sha }}
       run: |
-        echo echo "sha=${HEAD_SHA:-${VERSION:-${SHA}}}" >> $GITHUB_OUTPUT
+        echo "sha=${HEAD_SHA:-${VERSION:-${SHA}}}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
[GE-663](https://toptal-core.atlassian.net/browse/GE-663)

### Description

To fix the warning on Blackfish-Frontend project, we updated the `get-workflow-sha` job. Also `build-push-release-image` jobs `yarn install` is upgraded to latest version as per the suggestion on [latest PR](https://github.com/toptal/davinci-github-actions/pull/110).

### How to test

- Checks should pass
- Will be tested through blackfish frontend PR

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[GE-663]: https://toptal-core.atlassian.net/browse/GE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ