### PR TITLE
feat: add action to get slack name based on email

### DIFF
--- a/.changeset/fresh-crabs-cheat.md
+++ b/.changeset/fresh-crabs-cheat.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### get-user-slack-from-email
+
+- add new github action

--- a/get-user-slack-from-email/README.md
+++ b/get-user-slack-from-email/README.md
@@ -19,13 +19,18 @@ The list of arguments, that are used in GH Action:
 
 The list of variables, that are returned by GH Action:
 
-| name         | type   | description                        |
-| ------------ | ------ | ---------------------------------- |
-| `slack-name` | string | Slack user name/slack user handler |
+| name           | type   | description   |
+| -------------- | ------ | ------------- |
+| `slack-userId` | string | Slack user id |
 
 ### ENV Variables
 
-Not specified
+All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
+This is a list of ENV Variables that are used in GH Action:
+
+| name              | description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `SLACK_BOT_TOKEN` | Slack bot token with scope "users:read.email" **Read-only**. |
 
 ### Usage
 

--- a/get-user-slack-from-email/README.md
+++ b/get-user-slack-from-email/README.md
@@ -1,0 +1,37 @@
+## Get user slack from email
+
+Get user slack handler based on user email
+
+### Description
+
+This GH Action checks if user login belongs to the team member
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name              | type   | required | default | description                                                                                              |
+| ----------------- | ------ | -------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `email`           | string | ✅        |         | User email                                                                                               |
+| `slack-bot-token` | string | ✅        |         | Slack bot token with scope "users:read.email" **Read-only**. If undefined, `env.SLACK_BOT_TOKEN` is used |
+
+### Outputs
+
+The list of variables, that are returned by GH Action:
+
+| name         | type   | description                        |
+| ------------ | ------ | ---------------------------------- |
+| `slack-name` | string | Slack user name/slack user handler |
+
+### ENV Variables
+
+Not specified
+
+### Usage
+
+```yaml
+  - uses: toptal/davinci-github-actions/get-user-slack-from-email@v4.4.2
+    with:
+      email: tylerdurden@toptal.com
+      slack-bot-token: slack-bot-token
+```

--- a/get-user-slack-from-email/action.yml
+++ b/get-user-slack-from-email/action.yml
@@ -1,0 +1,31 @@
+name: Get user slack from email
+description: Get user slack handler based on user email
+inputs:
+  email:
+    required: true
+    description: User email
+  slack-bot-token:
+    required: true
+    description: Slack bot token with scope "users:read.email" **Read-only**. If undefined, `env.SLACK_BOT_TOKEN` is used
+
+outputs:
+  slack-name:
+    description: "Slack user name/slack user handler"
+    value: ${{ steps.slack-user.outputs.name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get slack user name
+      id: slack-user
+      shell: bash
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token || env.SLACK_BOT_TOKEN }}
+      run: |
+        data=$(curl -X POST -H "Content-Type: application/json; charset=utf-8" \
+          -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN }}" \
+          --data '{"email":"${{ inputs.email }}"' \
+          https://slack.com/api/users.lookupByEmail)
+        echo $data
+        name=$(echo $data | jq '.user.name')
+        echo "name=$name" >> $GITHUB_OUTPUT

--- a/get-user-slack-from-email/action.yml
+++ b/get-user-slack-from-email/action.yml
@@ -1,5 +1,9 @@
 name: Get user slack from email
-description: Get user slack handler based on user email
+description: |
+  Get user slack handler based on user email
+  ****
+  envInputs:
+    SLACK_BOT_TOKEN: Slack bot token with scope "users:read.email" **Read-only**.
 inputs:
   email:
     required: true
@@ -9,9 +13,9 @@ inputs:
     description: Slack bot token with scope "users:read.email" **Read-only**. If undefined, `env.SLACK_BOT_TOKEN` is used
 
 outputs:
-  slack-name:
-    description: "Slack user name/slack user handler"
-    value: ${{ steps.slack-user.outputs.name }}
+  slack-userId:
+    description: "Slack user id"
+    value: ${{ steps.slack-user.outputs.slackId }}
 
 runs:
   using: composite
@@ -22,10 +26,10 @@ runs:
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token || env.SLACK_BOT_TOKEN }}
       run: |
-        data=$(curl -X POST -H "Content-Type: application/json; charset=utf-8" \
+        data=$(curl -X POST https://slack.com/api/users.lookupByEmail \
           -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN }}" \
-          --data '{"email":"${{ inputs.email }}"' \
-          https://slack.com/api/users.lookupByEmail)
+          -H "Content-Type: application/x-www-form-urlencoded" \
+          -d 'email=${{ inputs.email }}')
         echo $data
-        name=$(echo $data | jq '.user.name')
-        echo "name=$name" >> $GITHUB_OUTPUT
+        slackId=$(echo $data | jq -r '.user.id')
+        echo "slackId=$slackId" >> $GITHUB_OUTPUT

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -10,12 +10,12 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 
 The list of arguments, that are used in GH Action:
 
-| name            | type   | required | default | description                                                                                                               |
-| --------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `npm-token`     | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
-| `cache-version` | string |          | 0.0     | Cache version                                                                                                             |
-| `path`          | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
-| `checkout-token`          | string |          |        | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners command                                                |
+| name             | type   | required | default | description                                                                                                               |
+| ---------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `npm-token`      | string |          |         | Access token type **Read-only**. Required for repository with private dependencies. If undefined, `env.NPM_TOKEN` is used |
+| `cache-version`  | string |          | 0.0     | Cache version                                                                                                             |
+| `path`           | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                |
+| `checkout-token` | string |          |         | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners                                         |
 
 ### Outputs
 


### PR DESCRIPTION
### Description

Add github action to retrieve slack name from user email

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
