### PR TITLE
feat: add new input to build-publish-alpha-package

### DIFF
--- a/.changeset/hot-dragons-deny.md
+++ b/.changeset/hot-dragons-deny.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### build-publish-alpha-package
+
+- add new input `root-folder` to specify the root folder of a package to be published

--- a/.changeset/hot-dragons-deny.md
+++ b/.changeset/hot-dragons-deny.md
@@ -1,5 +1,5 @@
 ---
-'davinci-github-actions': minor
+'davinci-github-actions': major
 ---
 
 ---
@@ -7,3 +7,4 @@
 ### build-publish-alpha-package
 
 - add new input `root-folder` to specify the root folder of a package to be published
+- build-publish-alpha-package now requires davinci-engine@9.1.0 or later

--- a/build-publish-alpha-package/README.md
+++ b/build-publish-alpha-package/README.md
@@ -14,10 +14,11 @@ Uses `yarn build:package` command to build the package.
 
 The list of arguments, that are used in GH Action:
 
-| name        | type   | required | default | description                                           |
-| ----------- | ------ | -------- | ------- | ----------------------------------------------------- |
-| `npm-token` | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
-| `branch`    | string | ✅        |         | Name of the branch that will be published             |
+| name          | type   | required | default | description                                           |
+| ------------- | ------ | -------- | ------- | ----------------------------------------------------- |
+| `npm-token`   | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
+| `branch`      | string | ✅        |         | Name of the branch that will be published             |
+| `root-folder` | string |          | .       | Root folder of a package to be published              |
 
 ### Outputs
 

--- a/build-publish-alpha-package/README.md
+++ b/build-publish-alpha-package/README.md
@@ -18,7 +18,7 @@ The list of arguments, that are used in GH Action:
 | ------------- | ------ | -------- | ------- | ----------------------------------------------------- |
 | `npm-token`   | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
 | `branch`      | string | ✅        |         | Name of the branch that will be published             |
-| `root-folder` | string |          | .       | Root folder of a package to be published              |
+| `root-folder` | string |          |         | Root folder of a package to be published              |
 
 ### Outputs
 

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -12,6 +12,9 @@ inputs:
   branch:
     required: true
     description: 'Name of the branch that will be published || string'
+  root-folder:
+    default: .
+    description: 'Root folder of a package to be published || string'
 
 runs:
   using: composite
@@ -40,6 +43,7 @@ runs:
       shell: bash
       env:
         BRANCH: ${{ inputs.branch }}
+        ROOT_FOLDER: ${{ inputs.root-folder }}
       run: |
         # set .github folder as an unchanged, because lerna throws an error if there are uncommited changes
         git checkout .github/
@@ -48,6 +52,7 @@ runs:
         --alpha \
         --outputVersion .version \
         --branch "$BRANCH" \
+        --publishRootFolder "$ROOT_FOLDER"
 
         versions=$(cat .version)
         [ -z "$versions" ] && exit 1

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
     description: 'Name of the branch that will be published || string'
   root-folder:
-    default: .
+    required: false
     description: 'Root folder of a package to be published || string'
 
 runs:

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -52,7 +52,7 @@ runs:
         --alpha \
         --outputVersion .version \
         --branch "$BRANCH" \
-        --publishRootFolder "$ROOT_FOLDER"
+        --publishRootFolder $ROOT_FOLDER
 
         versions=$(cat .version)
         [ -z "$versions" ] && exit 1


### PR DESCRIPTION
[FX-3737](https://toptal-core.atlassian.net/browse/FX-3737)

### Description

Added an ability to pass Davinci root folder for alpha publishing (defaults to ".")

### How to test

- See if the code looks good
- See if the defaults make sense
- Test the branch action in a product using the GH action to see if it works ([Picasso test PR](https://github.com/toptal/picasso/pull/3398))

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-3737]: https://toptal-core.atlassian.net/browse/FX-3737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ