### PR TITLE
fix: [FX-2626] set up danger env variable for self-hosted runners

### DIFF
--- a/.changeset/update.md
+++ b/.changeset/update.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- update danger environment variable for proper API domain requests

--- a/.changeset/update.md
+++ b/.changeset/update.md
@@ -4,4 +4,4 @@
 
 ---
 
-- update danger environment variable for proper API domain requests
+- set the `danger` environment variable to ensure that all API requests are performed on the correct domain

--- a/danger/action.yml
+++ b/danger/action.yml
@@ -6,8 +6,9 @@ runs:
   steps:
     - shell: bash
       env:
-        # The self-hosted runners overrides the GITHUB_URL to incorrect value,
-        # and may use this env variable for another purpose.
-        # DANGER_GITHUB_API_BASE_URL has higher priority
+        # Self-hosted runners can override the GITHUB_URL environment variable
+        # to a potentially incorrect value, and this variable may also be used
+        # for other purposes beyond communicating with the GitHub API. 
+        # The DANGER_GITHUB_API_BASE_URL env variable takes higher priority 
         DANGER_GITHUB_API_BASE_URL: https://api.github.com
       run: yarn davinci-ci danger

--- a/danger/action.yml
+++ b/danger/action.yml
@@ -6,6 +6,5 @@ runs:
   steps:
     - shell: bash
       env:
-        # We must specify the base URL for the GitHub API because the self-hosted runner overrides the default one
         DANGER_GITHUB_API_BASE_URL: https://api.github.com
       run: yarn davinci-ci danger

--- a/danger/action.yml
+++ b/danger/action.yml
@@ -5,4 +5,7 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        # We must specify the base URL for the GitHub API because the self-hosted runner overrides the default one
+        DANGER_GITHUB_API_BASE_URL: https://api.github.com
       run: yarn davinci-ci danger

--- a/danger/action.yml
+++ b/danger/action.yml
@@ -6,5 +6,8 @@ runs:
   steps:
     - shell: bash
       env:
+        # The self-hosted runners overrides the GITHUB_URL to incorrect value,
+        # and may use this env variable for another purpose.
+        # DANGER_GITHUB_API_BASE_URL has higher priority
         DANGER_GITHUB_API_BASE_URL: https://api.github.com
       run: yarn davinci-ci danger


### PR DESCRIPTION
[FX-2626]

### Description

Self-hosted runners may override `GITHUB_URL` variable, so requests may be performed incorectly.

This code explains how danger defined API URL: https://github.com/danger/danger-js/blob/main/source/platforms/github/GitHubAPI.ts#LL452C96-L452C118

### How to test

- Use branch version in an existing GH Workflow with defined self-hosted runners

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-2626]: https://toptal-core.atlassian.net/browse/FX-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ