### PR TITLE
chore: update action versions

### DIFF
--- a/.changeset/new-icons-sleep.md
+++ b/.changeset/new-icons-sleep.md
@@ -4,4 +4,4 @@
 
 ---
 
-- support for `node < 14` is dropped; `actions/checkout`, `docker/metadata-action`, `xt0rted/pull-request-comment-branch`, `actions/upload-artifact`, `actions/github-script` dependencies were updated
+- support for `node < 14` was dropped; `actions/checkout`, `docker/metadata-action`, `xt0rted/pull-request-comment-branch`, `actions/upload-artifact`, `actions/github-script` dependencies were updated

--- a/.changeset/new-icons-sleep.md
+++ b/.changeset/new-icons-sleep.md
@@ -4,4 +4,4 @@
 
 ---
 
-- update dependencies (`actions/checkout`, `docker/metadata-action`, `xt0rted/pull-request-comment-branch`, `actions/upload-artifact`, `actions/github-script`)
+- support for `node < 14` is dropped; `actions/checkout`, `docker/metadata-action`, `xt0rted/pull-request-comment-branch`, `actions/upload-artifact`, `actions/github-script` dependencies were updated

--- a/.changeset/new-icons-sleep.md
+++ b/.changeset/new-icons-sleep.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': major
+---
+
+---
+
+- update dependencies (`actions/checkout`, `docker/metadata-action`, `xt0rted/pull-request-comment-branch`, `actions/upload-artifact`, `actions/github-script`)

--- a/.github/workflows/handle-contribution.yml
+++ b/.github/workflows/handle-contribution.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Call notify jira about contribution
     steps:
-      # TODO: revert / change version of "notify-jira-about-contribution" to latest in the follow-up
-      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@FX-3787-update-external-dependencies
+      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v4.10.4
         with:
           team: frontend-experience-eng
           repo: ${{ github.event.repository.name }}

--- a/.github/workflows/handle-contribution.yml
+++ b/.github/workflows/handle-contribution.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Call notify jira about contribution
     steps:
-      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v4.10.4
+      # TODO: revert / change version of "notify-jira-about-contribution" to latest in the follow-up
+      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@FX-3787-update-external-dependencies
         with:
           team: frontend-experience-eng
           repo: ${{ github.event.repository.name }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -36,7 +36,7 @@ jobs:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -53,7 +53,7 @@ jobs:
     name: Trufflehog Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.4.0
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4.1.1
+      uses: docker/metadata-action@v4.3.0
       with:
         images: |
           gcr.io/toptal-hub/${{ inputs.image-name }}

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -19,7 +19,7 @@ runs:
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain
-      uses: google-github-actions/setup-gcloud@v1.0.1
+      uses: google-github-actions/setup-gcloud@v1.1.0
 
     - name: Check types cache
       uses: actions/cache@v3

--- a/get-workflow-sha/action.yml
+++ b/get-workflow-sha/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - id: branch
       if: github.event_name == 'issue_comment'
-      uses: xt0rted/pull-request-comment-branch@v1.3.0
+      uses: xt0rted/pull-request-comment-branch@0cb1cc92a57e44274e9d862202f0d40df70f4478
 
     - id: specify-sha
       name: Specify SHA

--- a/integration-tests/action.yml
+++ b/integration-tests/action.yml
@@ -36,7 +36,7 @@ runs:
       run: yarn $COMMAND
 
     - name: Store Cypress Screenshots Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: cypress-screenshots

--- a/is-team-member/action.yml
+++ b/is-team-member/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@v6
       id: check-team-member
       with:
         github-token: ${{ inputs.github-token }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -32,7 +32,8 @@ runs:
         pull-number: ${{ inputs.pull-number }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    - uses: toptal/davinci-github-actions/is-team-member@v4.4.2
+    # TODO: revert / change version of "notify-jira-about-contribution" to latest in the follow-up
+    - uses: toptal/davinci-github-actions/is-team-member@FX-3787-update-external-dependencies
       id: is-team-member
       with:
         team: ${{ inputs.team }}
@@ -74,7 +75,7 @@ runs:
 
     - name: Greet author
       if: ${{ fromJson(steps.is-pr-eligible.outputs.result) == true && fromJson(steps.jira-issue-can-be-created.outputs.result) == true }}
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -32,8 +32,7 @@ runs:
         pull-number: ${{ inputs.pull-number }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    # TODO: revert / change version of "notify-jira-about-contribution" to latest in the follow-up
-    - uses: toptal/davinci-github-actions/is-team-member@FX-3787-update-external-dependencies
+    - uses: toptal/davinci-github-actions/is-team-member@v4.4.2
       id: is-team-member
       with:
         team: ${{ inputs.team }}

--- a/status-check/action.yml
+++ b/status-check/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Set status check
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       env:
         STATUS_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         STATUS_STATE: ${{ inputs.state }}


### PR DESCRIPTION
[FX-3787](https://toptal-core.atlassian.net/browse/FX-3787)

### Description

⚠️ There will be a follow-up for changes in https://github.com/toptal/davinci-github-actions/pull/135/commits/01d5e17fb043a9ab409e4dc6c895457604ad4773

As the first step of https://toptal-core.atlassian.net/browse/FX-3787, this pull request updates all the dependencies.

Problem with https://github.com/xt0rted/pull-request-comment-branch/issues/340 (dangerous to use `@main` or `@latest`, so using a SHA as [it is safer](https://michaelheap.com/ensure-github-actions-pinned-sha/))

### How to test

- No changes in behaviour are expected
- Pull request in `picasso` – https://github.com/toptal/picasso/pull/3432
- Pull request in `davinci` – https://github.com/toptal/davinci/pull/1957

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-3787]: https://toptal-core.atlassian.net/browse/FX-3787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ