### PR TITLE
fix: update used action version

### DIFF
--- a/.changeset/selfish-bananas-brake.md
+++ b/.changeset/selfish-bananas-brake.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- the `Ana06/get-changed-files` was replaced with `masesgroup/retrieve-changed-files`

--- a/report-affected-packages/action.yml
+++ b/report-affected-packages/action.yml
@@ -8,7 +8,7 @@ runs:
       with:
         node-version: 16
 
-    - uses: Ana06/get-changed-files@v2.1.0
+    - uses: masesgroup/retrieve-changed-files@2e42889ff54e0810cf088f73a38a2db5a9d0684f
       id: files
       with:
         format: 'json'


### PR DESCRIPTION
No Jira ticket.

### Description

On of the dependencies was missed during https://github.com/toptal/davinci-github-actions/pull/135 – the `Ana06/get-changed-files` (which is in fact https://github.com/jitterbit/get-changed-files) needs to be replaced by https://github.com/masesgroup/retrieve-changed-files which is the fork but with fixes for deprecated `set-output` methods.

More infromation in https://github.com/jitterbit/get-changed-files/issues/55 and https://toptal-core.slack.com/archives/CERF5NHT3/p1678820571894699.

### How to test

- Alpha package was tested in Talent Portal Frontend by comparing GHA logs (https://github.com/toptal/talent-portal-frontend/actions/runs/4418981575/jobs/7746817089#step:4:55 and https://github.com/toptal/talent-portal-frontend/actions/runs/4493260737/jobs/7904241851?pr=4733#step:4:1)


https://user-images.githubusercontent.com/1390758/227003138-a661ef1b-649e-4230-843c-f7f6fa379159.mp4


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)
- [x] Close and remove branch in https://github.com/toptal/talent-portal-frontend/pull/4733 before the merge 

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
