### PR TITLE
fix: specify publishRootFolder only when input is provided

### DIFF
--- a/.changeset/good-houses-type.md
+++ b/.changeset/good-houses-type.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### build-publish-alpha-package
+
+- fixed a bug with an action failing when root-folder is not specified

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -48,11 +48,18 @@ runs:
         # set .github folder as an unchanged, because lerna throws an error if there are uncommited changes
         git checkout .github/
 
-        yarn davinci-engine publish-package \
-        --alpha \
-        --outputVersion .version \
-        --branch "$BRANCH" \
-        --publishRootFolder $ROOT_FOLDER
+        if [ -n "${ROOT_FOLDER}" ]; then
+          yarn davinci-engine publish-package \
+          --alpha \
+          --outputVersion .version \
+          --branch "$BRANCH" \
+          --publishRootFolder $ROOT_FOLDER
+        else
+          yarn davinci-engine publish-package \
+          --alpha \
+          --outputVersion .version \
+          --branch "$BRANCH"
+        fi
 
         versions=$(cat .version)
         [ -z "$versions" ] && exit 1

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -48,18 +48,10 @@ runs:
         # set .github folder as an unchanged, because lerna throws an error if there are uncommited changes
         git checkout .github/
 
-        if [ -n "${ROOT_FOLDER}" ]; then
-          yarn davinci-engine publish-package \
+        yarn davinci-engine publish-package \
           --alpha \
           --outputVersion .version \
-          --branch "$BRANCH" \
-          --publishRootFolder $ROOT_FOLDER
-        else
-          yarn davinci-engine publish-package \
-          --alpha \
-          --outputVersion .version \
-          --branch "$BRANCH"
-        fi
+          --branch "$BRANCH" ${ROOT_FOLDER:+"--publishRootFolder=$ROOT_FOLDER"}
 
         versions=$(cat .version)
         [ -z "$versions" ] && exit 1


### PR DESCRIPTION
[FX-3832](https://toptal-core.atlassian.net/browse/FX-3832)

### Description

Alpha package release should now work without specifying `root-folder` input.

### How to test

- See if the release goes through in the [example job](https://github.com/toptal/picasso/actions/runs/4533878996/jobs/7987287150?pr=3457#step:7:350) (failed for a different reason, but take a look at how the correct command is executed on the line that is linked)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-3832]: https://toptal-core.atlassian.net/browse/FX-3832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ