### PR TITLE
chore: pass checkout-token from deploy-storybook

### DIFF
--- a/.changeset/twenty-pots-hide.md
+++ b/.changeset/twenty-pots-hide.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- pass checkout-token from deploy-storybook GH Action to yarn-install

--- a/.changeset/twenty-pots-hide.md
+++ b/.changeset/twenty-pots-hide.md
@@ -3,5 +3,4 @@
 ---
 
 ---
-
 - pass checkout-token from deploy-storybook GH Action to yarn-install

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -23,6 +23,7 @@ The list of arguments, that are used in GH Action:
 | `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                    |
 | `generate-types-command` | string                                     |          | false              | Command to generate gql types                                                           |
 | `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. . |
+| `checkout-token`         | string                                     |          |                    | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners       |
 
 ### Outputs
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -51,6 +51,9 @@ inputs:
     description: Event number of the original pr, in case event number or issue number is not present. .
     required: false
     default: false
+  checkout-token:
+    description: Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners
+    required: false
 
 runs:
   using: composite
@@ -63,6 +66,8 @@ runs:
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
       uses: toptal/davinci-github-actions/yarn-install@v6.0.0
+      with:
+        checkout-token: ${{ inputs.checkout-token }}
 
     - name: Generate Types
       if: ${{ inputs.generate-types-command != 'false' }}


### PR DESCRIPTION
[FX-3842]

### Description

`Deploy Storybook` **GH** Action does not pass `checkout-token` to `yarn install` **GH** Action . Therefore, `yarn install` GH Action does not work properly on self-hosted runners.

### How to test

- Use this branch as a version


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-3842]: https://toptal-core.atlassian.net/browse/FX-3842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ