### PR TITLE
fix: use proper version of reused GHA

### DIFF
--- a/get-workflow-sha/action.yml
+++ b/get-workflow-sha/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - id: branch
       if: github.event_name == 'issue_comment'
-      uses: xt0rted/pull-request-comment-branch@0cb1cc92a57e44274e9d862202f0d40df70f4478
+      uses: xt0rted/pull-request-comment-branch@v2.0.0
 
     - id: specify-sha
       name: Specify SHA


### PR DESCRIPTION
No Jira ticket.

### Description

This pull request updates the version of one of the reused GHAs (https://github.com/xt0rted/pull-request-comment-branch/blob/main/CHANGELOG.md#200---2023-03-29) and fixes the error with alpha releases.

### How to test

- version bump

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
