### PR TITLE
feat: add support of davinci-app helm chart

### DIFF
--- a/.changeset/nasty-cheetahs-exercise.md
+++ b/.changeset/nasty-cheetahs-exercise.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### extract-env-variables
+
+- add support of old and new davinci-app charts. Append env variables with `davinci-app` prefix.

--- a/extract-env-variables/action.yml
+++ b/extract-env-variables/action.yml
@@ -33,5 +33,5 @@ runs:
             .toString()
             .split(/\n/)
             .filter(line => !line.startsWith('#') && line.length > 0)
-            .map(line => `ENV.${line}`)
+            .map(line => `ENV.${line},davinci-app.ENV.${line}`)
             .join(',')


### PR DESCRIPTION
### Description

Support both charts - davinci-app and old chart.
Similar to https://github.com/toptal/staff-portal/blob/8151ef9feda7e12cf6c5d50d9bfe144a102df5b7/.github/scripts/readEnvVars.sh#L9

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
