### PR TITLE
Use empty env file for storybook temploys

### DIFF
--- a/.changeset/tough-sheep-provide.md
+++ b/.changeset/tough-sheep-provide.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### deploy-storybook
+
+- fix when no .env file is used for a project

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -157,7 +157,7 @@ runs:
             "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
             "RELEASE": "${{ env.RELEASE }}",
             "TAG": "${{ inputs.sha }}",
-            "ENV": "${{ steps.env-variables.outputs.variables }}"
+            "ENV": "${{ steps.env-variables.outputs.variables || 'ENV=null' }}"
           }
         job_timeout: 1200
 


### PR DESCRIPTION
### Description

If a project does not use `.env` files we still need to pass `ENV` to the Jenkins job. By default, it receives `ENV=null`.

Otherwise, helm tries to `--set` empty string and does not recognize RELEASE and CHART passed to the command

<img width="1441" alt="Screenshot 2023-04-04 at 12 19 46" src="https://user-images.githubusercontent.com/2836281/229762497-2040f890-e757-4084-9e55-d85cea8dbee5.png">

Example run https://jenkins-build.toptal.net/job/client-portal/job/client-portal-storybook-temploy-helm-run/8/console

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
