### PR TITLE
feat: depend only on the major version of node

### DIFF
--- a/.changeset/serious-hats-scream.md
+++ b/.changeset/serious-hats-scream.md
@@ -1,0 +1,13 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+### build-publish-alpha
+
+- change node version to follow 14 major
+
+### build-push-image
+
+- change node version to follow 14 major

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: '14.17'
+        node-version: 14
 
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: '14.17'
+        node-version: 14
 
     - id: meta-latest
       shell: bash


### PR DESCRIPTION
### Description

You are having problems with package [releases in Picasso](https://github.com/toptal/picasso/actions/runs/4646758303/jobs/8223366088) because of a new minimum version required for execa, which we recently bumped on [Picasso](https://github.com/toptal/picasso/commit/ba50d384f2888192d2c6d3d9eed7e896eff0435e)

### How to test

- You can test it on Picasso by creating a PR using the patched workflow

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
