### PR TITLE
chore: update node versions in github workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 16.x
+          node-version: 16
 
       - uses: ./yarn-install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '14.17'
+          node-version: 16
 
       - uses: ./yarn-install
 


### PR DESCRIPTION
### Description

We need to update node version from 14 to 16 in GH Workflows

### How to test

- Tested in others projects. As it's an infrastructure fix, it will be checked after merging

### Development checks

No changeset is needed. It's internal change

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
