### PR TITLE
chore: [FX-3909] add Jira deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 env:
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   GITHUB_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
 
 jobs:
   release:
@@ -92,3 +93,17 @@ jobs:
           slack-message: "A new PR was merged to davinci-github-actions :parrotspin:"
         env:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+
+      - name: Get new tag version
+        id: tag-version
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        run: |
+          echo LATEST_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_OUTPUT
+
+      - uses: toptal/davinci-github-actions/create-jira-deployment@v6.3.0
+        name: Create Production Jira deployment
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        with:
+          token: ${{ env.DEVBOT_TOKEN }}
+          environment: production
+          environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}

--- a/.github/workflows/test-jira-deployments.yml
+++ b/.github/workflows/test-jira-deployments.yml
@@ -1,0 +1,41 @@
+name: Test Jira Deployments
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fx-3909-add-jira-deployments
+
+jobs:
+  release:
+    name: Trigger Jira Deployments
+    runs-on: ubuntu-latest
+    env:
+      DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          
+      - name: Get new tag version
+        id: tag-version
+        run: |
+          echo LATEST_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_OUTPUT
+
+      - uses: toptal/davinci-github-actions/create-jira-deployment@v6.3.0
+        name: Create Production Jira deployment
+        with:
+          token: ${{ env.DEVBOT_TOKEN }}
+          environment: production
+          environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}
+
+      - uses: toptal/davinci-github-actions/create-jira-deployment@v6.3.0
+        name: Create Alpha Jira deployment
+        with:
+          token: ${{ env.DEVBOT_TOKEN }}
+          environment: alpha-package
+          environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}


### PR DESCRIPTION
[FX-3909]

### Description

We need to add Jira deployments to Davinci GH Actions. 

### How to test

- See at temporary GH Workflow `test-jira-deployments`

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
