### PR TITLE
Use inputs.path in yarn-install action

### DIFF
--- a/.changeset/light-apricots-dance.md
+++ b/.changeset/light-apricots-dance.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': minor
+---
+
+---
+
+- change to use inputs.path in yarn-install action when provided

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -33,7 +33,7 @@ Not specified
 ### Usage
 
 ```yaml
-  - uses: toptal/davinci-github-actions/yarn-install@v6.4.0
+  - uses: toptal/davinci-github-actions/yarn-install@v6.5.0
     with:
       npm-token: ${{ env.NPM_TOKEN }}
       npm-gar-token: ${{ env.NPM_GAR_TOKEN }}

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -16,7 +16,7 @@ The list of arguments, that are used in GH Action:
 | `cache-version`  | string |          | 0.0     | Cache version                                                                                                                                                                                                                               |
 | `path`           | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                                                                                                                                  |
 | `checkout-token` | string |          |         | Repository checkout access token `GITHUB_TOKEN`. Required for self-hosted runners                                                                                                                                                           |
-| `npm-gar-token`  | string |          |         | npm Artifact Registry (AR) access token (`NPM_GAR_TOKEN` secret available to all private repos). Required when using self-hosted runners with npm in AR. The npm registry in AR works as a proxy-registry, downloading and storing public npm packages |
+| `npm-gar-token`  | string |          |         | Repository npm Artifact Registry access token `NPM_GAR_TOKEN`. Required when using self-hosted runners with npm in GAR (Google Artifact Registry, the npm registry works as a proxy-cache, downloading and storing the public npm packages) |
 
 ### Outputs
 

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   path:
     description: Relative path under $GITHUB_WORKSPACE where to run `yarn install` command
-    default: .
+    default: ./
     required: false
   checkout-token:
     description: Repository checkout access token `GITHUB_TOKEN`. Required for self-hosted runners
@@ -86,16 +86,16 @@ runs:
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'inf-gha-runners-ci')"
       run: |
-        echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > .npmrc &&
-        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> .npmrc &&
-        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:_password=${{ inputs.npm-gar-token }}" >> .npmrc &&
+        echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}.npmrc &&
+        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}.npmrc &&
+        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:_password=${{ inputs.npm-gar-token }}" >> ${{ inputs.path }}.npmrc &&
 
-        echo "@toptal:registry=https://registry.npmjs.org/" >> .npmrc &&
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> .npmrc &&
+        echo "@toptal:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}.npmrc &&
+        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}.npmrc &&
 
-        echo "@topkit:registry=https://registry.npmjs.org/" >> .npmrc &&
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> .npmrc &&
-        echo "always-auth=true" >> .npmrc
+        echo "@topkit:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}.npmrc &&
+        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}.npmrc &&
+        echo "always-auth=true" >> ${{ inputs.path }}.npmrc
       shell: bash
 
     # This step changes the public npm registry in yarn.lock file to npm in AR
@@ -103,10 +103,10 @@ runs:
     - name: Change registry in yarn.lock file to npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'inf-gha-runners-ci')"
       run: |
-        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" yarn.lock
-        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" yarn.lock
-        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@toptal/#https://registry.npmjs.org/@toptal/#g" yarn.lock
-        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@topkit/#https://registry.npmjs.org/@topkit/#g" yarn.lock
+        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}yarn.lock
+        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}yarn.lock
+        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@toptal/#https://registry.npmjs.org/@toptal/#g" ${{ inputs.path }}yarn.lock
+        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@topkit/#https://registry.npmjs.org/@topkit/#g" ${{ inputs.path }}yarn.lock
       shell: bash
 
     - name: yarn install

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   path:
     description: Relative path under $GITHUB_WORKSPACE where to run `yarn install` command
-    default: ./
+    default: .
     required: false
   checkout-token:
     description: Repository checkout access token `GITHUB_TOKEN`. Required for self-hosted runners
@@ -86,16 +86,16 @@ runs:
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'inf-gha-runners-ci')"
       run: |
-        echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}.npmrc &&
-        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}.npmrc &&
-        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:_password=${{ inputs.npm-gar-token }}" >> ${{ inputs.path }}.npmrc &&
+        echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
+        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
+        echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:_password=${{ inputs.npm-gar-token }}" >> ${{ inputs.path }}/.npmrc &&
 
-        echo "@toptal:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}.npmrc &&
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}.npmrc &&
+        echo "@toptal:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}/.npmrc &&
+        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}/.npmrc &&
 
-        echo "@topkit:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}.npmrc &&
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}.npmrc &&
-        echo "always-auth=true" >> ${{ inputs.path }}.npmrc
+        echo "@topkit:registry=https://registry.npmjs.org/" >> ${{ inputs.path }}/.npmrc &&
+        echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token || env.NPM_TOKEN }}" >> ${{ inputs.path }}/.npmrc &&
+        echo "always-auth=true" >> ${{ inputs.path }}/.npmrc
       shell: bash
 
     # This step changes the public npm registry in yarn.lock file to npm in AR
@@ -103,10 +103,10 @@ runs:
     - name: Change registry in yarn.lock file to npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'inf-gha-runners-ci')"
       run: |
-        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}yarn.lock
-        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}yarn.lock
-        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@toptal/#https://registry.npmjs.org/@toptal/#g" ${{ inputs.path }}yarn.lock
-        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@topkit/#https://registry.npmjs.org/@topkit/#g" ${{ inputs.path }}yarn.lock
+        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
+        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
+        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@toptal/#https://registry.npmjs.org/@toptal/#g" ${{ inputs.path }}/yarn.lock
+        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/@topkit/#https://registry.npmjs.org/@topkit/#g" ${{ inputs.path }}/yarn.lock
       shell: bash
 
     - name: yarn install


### PR DESCRIPTION

### Description

Change to use inputs.path in yarn-install action when provided.


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
