### PR TITLE
fix: [PRL-🩹] do not use `-` at the end of the domain name and trim it to 63 chars

### DIFF
--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -170,8 +170,9 @@ runs:
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
+          const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}'].join('-').substring(0, 45)
+          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 63))
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.rest.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -171,7 +171,7 @@ runs:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45)
+          const name = ['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}'].join('-').substring(0, 45)
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.rest.issues.createComment({ issue_number: number, owner, repo, body })


### PR DESCRIPTION
[PRL-🩹]

### Description

It looks like we are not using the same [approach](https://github.com/toptal/inf-helm/blob/36a62a746fc8cd4780c35a27f7881c390ef2814f/charts/davinci-app/templates/_helpers.tpl#L16) as `helm` does.

* We need to trim name of the storybook temploy to 63 chars
* Remove `-` at the end

Here: https://github.com/toptal/staff-portal/pull/10378#issuecomment-1549746981

Domain is https://staff-portal-pr-10378-storybook-staff-portal-.toptal.rocks/ but it should be https://staff-portal-pr-10378-storybook-staff-portal.toptal.rocks/

Run: https://jenkins-build.toptal.net/view/Staff-portal/job/Staff-portal/job/staff-portal-storybook-temploy-helm-run/82/console

```
09:04:53  NAMESPACE: staff-portal-pr-10378-storybook
09:04:53  STATUS: deployed
09:04:53  REVISION: 1
09:04:53  NOTES:
09:04:53  Use the following URL to access your staff-portal-storybook instance:
09:04:53  https://staff-portal-pr-10378-storybook-staff-portal.toptal.rocks/
```

### How to test

1. Run temploy on this action in staff portal

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
