### PR TITLE
chore: remove gcr from build-push-image

### DIFF
--- a/.changeset/wet-brooms-tan.md
+++ b/.changeset/wet-brooms-tan.md
@@ -2,6 +2,4 @@
 'davinci-github-actions': major
 ---
 
----
-
 - build-push-image: avoid pushing images to Google Cloud Registy

--- a/.changeset/wet-brooms-tan.md
+++ b/.changeset/wet-brooms-tan.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': major
+---
+
+---
+
+- build-push-image: avoid pushing images to Google Cloud Registy

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -58,19 +58,11 @@ runs:
       uses: docker/metadata-action@v4.3.0
       with:
         images: |
-          gcr.io/toptal-hub/${{ inputs.image-name }}
           us-central1-docker.pkg.dev/toptal-hub/containers/${{ inputs.image-name }}
         tags: |
           type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ inputs.sha }}
         flavor: |
           latest=${{ steps.meta-latest.outputs.latest }}
-
-    - name: Login to Google Container Registry - GCR
-      uses: docker/login-action@v2
-      with:
-        registry: gcr.io
-        username: _json_key
-        password: ${{ env.GCR_ACCOUNT_KEY }}
 
     - name: Login to Google Artifact Registry - GAR
       uses: docker/login-action@v2


### PR DESCRIPTION
### Description

As a follow up task of migration to GAR, we need to get rid of Google Cloud registry as a registry to upload images. 

### How to test

- Use branch of `build-push-image` or `build-push-release-image` GH Actions to check pushing images

Tested in https://github.com/toptal/topapp-frontend/pull/211 

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
