### PR TITLE
chore: bump coverage-reporter gh action

### DIFF
--- a/.changeset/rude-rocks-behave.md
+++ b/.changeset/rude-rocks-behave.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+- bump coverage-reporter gh action

--- a/report-coverage/action.yml
+++ b/report-coverage/action.yml
@@ -28,7 +28,7 @@ runs:
         npx nyc merge "$FOLDER" merged-coverage/coverage.json
 
     - name: Print Coverage
-      uses: tj-actions/coverage-reporter@v5.1
+      uses: tj-actions/coverage-reporter@v5.3
       env:
         REPORTER: ${{ inputs.reporter }}
       with:


### PR DESCRIPTION
### Description

Bump coverage-reporter GH Action to fix warning about deprecated NodeJS version

### How to test

- Check this version in GH Workflow

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
