### PR TITLE
feat: add auto-inactive parameter to jira deployment

### DIFF
--- a/create-jira-deployment/README.md
+++ b/create-jira-deployment/README.md
@@ -10,11 +10,12 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 
 The list of arguments, that are used in GH Action:
 
-| name              | type   | required | default | description                                |
-| ----------------- | ------ | -------- | ------- | ------------------------------------------ |
-| `token`           | string | ✅        |         | GitHub token to create a deployment        |
-| `environment-url` | string | ✅        |         | URL of the environment                     |
-| `environment`     | string | ✅        |         | Name for the target deployment environment |
+| name              | type   | required | default | description                                                                                                                                                                    |
+| ----------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `token`           | string | ✅        |         | GitHub token to create a deployment                                                                                                                                            |
+| `environment-url` | string | ✅        |         | URL of the environment                                                                                                                                                         |
+| `environment`     | string | ✅        |         | Name for the target deployment environment                                                                                                                                     |
+| `auto-inactive`   | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment |
 
 ### Outputs
 

--- a/create-jira-deployment/action.yml
+++ b/create-jira-deployment/action.yml
@@ -12,6 +12,10 @@ inputs:
   environment:
     required: true
     description: 'Name for the target deployment environment'
+  auto-inactive:
+    required: false
+    description: Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment
+    default: true
 
 runs:
   using: composite
@@ -24,6 +28,7 @@ runs:
         token: ${{ inputs.token }}
         environment-url: ${{ inputs.environment-url }}
         environment: ${{ inputs.environment }}
+        auto-inactive: ${{ inputs.auto-inactive }}
 
     - name: Update deployment status on success
       if: ${{ success() }}


### PR DESCRIPTION
### Description

In order to add ability to prevent setting inactive status to GH deployments, we should add input parameter `auto-inactive: boolean`.

### Links 

https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#inactive-deployments
https://github.com/chrnorm/deployment-action#action-inputs


### How to test

- Check in GH Workflow

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
