### PR TITLE
chore: set node version to 16

### DIFF
--- a/.changeset/cold-snakes-boil.md
+++ b/.changeset/cold-snakes-boil.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': major
+---
+
+- all workflows use `node@16`

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 14
+        node-version: 16
 
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 14
+        node-version: 16
 
     - id: meta-latest
       shell: bash

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}


### PR DESCRIPTION
No Jira ticket.

### Description

This pull request set node version to 16 everywhere as a follow-up for https://github.com/toptal/davinci-github-actions/pull/161

### How to test

- All checks should pass

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
