### PR TITLE
chore: add architecture to install cache key

### DIFF
--- a/.changeset/curvy-coins-fetch.md
+++ b/.changeset/curvy-coins-fetch.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### yarn-install
+
+- add architecture to yarn-install cache key

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -66,7 +66,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
 
     - name: Cache yarn and node_modules folder
       if: "!contains(runner.name, 'inf-gha-runners-ci') || !inputs.checkout-token"
@@ -79,7 +79,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
 
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages


### PR DESCRIPTION
[TDESKAPP-1430]

### Description
Problem statement: the desktop-app project was facing issues with incompatible cache being shared.

After some investigation, I noticed that the install cache key we were using made no distinction between architectures. This PR addresses that. 

### How to test

- Run the new action on machines that have the same OS but different architectures

#### arm64

https://github.com/toptal/desktop-app/actions/runs/5320987850/jobs/9635490741#step:6:64

![image](https://github.com/toptal/davinci-github-actions/assets/10238432/0d18659b-c991-41a7-8666-df0cb13c4fe4)

#### x64

https://github.com/toptal/desktop-app/actions/runs/5320987850/jobs/9635490889#step:6:64

![image](https://github.com/toptal/davinci-github-actions/assets/10238432/75519b52-01c7-47f5-93d6-ef9640091b2d)


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[TDESKAPP-1430]: https://toptal-core.atlassian.net/browse/TDESKAPP-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ