### PR TITLE
feat: [CRT-6175] pass additional variables to upload source maps action

### DIFF
--- a/.changeset/clever-kiwis-grin.md
+++ b/.changeset/clever-kiwis-grin.md
@@ -1,5 +1,5 @@
 ---
-'davinci-github-actions': patch
+'davinci-github-actions': minor
 ---
 
 - pass additional variables to upload source maps action

--- a/.changeset/clever-kiwis-grin.md
+++ b/.changeset/clever-kiwis-grin.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- pass additional variables to upload source maps action

--- a/upload-source-maps/README.md
+++ b/upload-source-maps/README.md
@@ -12,10 +12,13 @@ This GH Action creates a new Sentry release and uploads source maps.
 
 The list of arguments, that are used in GH Action:
 
-| name                | type   | required | default | description                                              |
-| ------------------- | ------ | -------- | ------- | -------------------------------------------------------- |
-| `sentry-project`    | string | ✅        |         | The name of the Sentry project to upload source files to |
-| `working-directory` | string |          | .       | Specifies the working directory where the command is run |
+| name                  | type   | required | default | description                                              |
+| --------------------- | ------ | -------- | ------- | -------------------------------------------------------- |
+| `sentry-project`      | string | ✅        |         | The name of the Sentry project to upload source files to |
+| `working-directory`   | string |          | .       | Specifies the working directory where the command is run |
+| `url-prefix`          | string |          |         | Sets URL prefix for files                                |
+| `app-build-directory` | string |          |         | Directory of the built application                       |
+| `release-name`        | string |          |         | Name for the uploaded source maps                        |
 
 ### Outputs
 

--- a/upload-source-maps/action.yml
+++ b/upload-source-maps/action.yml
@@ -44,7 +44,7 @@ runs:
 
         if [[ $(yarn davinci-engine help) == *"sentry-upload-source-maps"* ]]
         then
-          yarn davinci-engine sentry-upload-source-maps --url-prefix=$URL_PREFIX --app-build-directory=$APP_BUILD_DIRECTORY --release-name=$RELEASE_NAME
+          yarn davinci-engine sentry-upload-source-maps --url-prefix="$URL_PREFIX" --app-build-directory="$APP_BUILD_DIRECTORY" --release-name="$RELEASE_NAME"
         else
           echo "Your current @toptal/davinci-engine version does not support uploading source maps to Sentry. Please update @toptal/davinci-engine package version in your app."
         fi

--- a/upload-source-maps/action.yml
+++ b/upload-source-maps/action.yml
@@ -44,7 +44,10 @@ runs:
 
         if [[ $(yarn davinci-engine help) == *"sentry-upload-source-maps"* ]]
         then
-          yarn davinci-engine sentry-upload-source-maps --url-prefix="$URL_PREFIX" --app-build-directory="$APP_BUILD_DIRECTORY" --release-name="$RELEASE_NAME"
+          yarn davinci-engine sentry-upload-source-maps \
+            ${URL_PREFIX:+"--url-prefix=$URL_PREFIX"} \
+            ${APP_BUILD_DIRECTORY:+"--app-build-directory=$APP_BUILD_DIRECTORY"} \
+            ${RELEASE_NAME:+"--release-name=$RELEASE_NAME"}
         else
           echo "Your current @toptal/davinci-engine version does not support uploading source maps to Sentry. Please update @toptal/davinci-engine package version in your app."
         fi

--- a/upload-source-maps/action.yml
+++ b/upload-source-maps/action.yml
@@ -13,6 +13,15 @@ inputs:
     required: false
     description: Specifies the working directory where the command is run
     default: '.'
+  url-prefix:
+    required: false
+    description: Sets URL prefix for files
+  app-build-directory:
+    required: false
+    description: Directory of the built application
+  release-name:
+    required: false
+    description: Name for the uploaded source maps
 
 runs:
   using: composite
@@ -21,6 +30,9 @@ runs:
       env:
         SENTRY_ORG: toptal
         SENTRY_PROJECT: ${{ inputs.sentry-project }}
+        URL_PREFIX: ${{ inputs.url-prefix }}
+        APP_BUILD_DIRECTORY: ${{ inputs.app-build-directory }}
+        RELEASE_NAME: ${{ inputs.release-name }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -32,7 +44,7 @@ runs:
 
         if [[ $(yarn davinci-engine help) == *"sentry-upload-source-maps"* ]]
         then
-          yarn davinci-engine sentry-upload-source-maps
+          yarn davinci-engine sentry-upload-source-maps --url-prefix=$URL_PREFIX --app-build-directory=$APP_BUILD_DIRECTORY --release-name=$RELEASE_NAME
         else
           echo "Your current @toptal/davinci-engine version does not support uploading source maps to Sentry. Please update @toptal/davinci-engine package version in your app."
         fi


### PR DESCRIPTION
[CRT-6175]

This PR aims to pass additional variables to upload source maps action.

### Description

Connected PRs:
- https://github.com/toptal/prospecting-assistant-extension/pull/53
- https://github.com/toptal/davinci/pull/2112 

### How to test
- review https://github.com/toptal/prospecting-assistant-extension/actions/runs/5910351517/job/16031861009#step:15:67 and check that source maps are uploaded to sentry
- review https://toptal.sentry.io/issues/4404725850/?project=4505561565560832&query=release%3Amaster-3af9d00d&referrer=release-issue-stream to see that source maps are working properly
    ![image](https://github.com/toptal/davinci/assets/4816942/b5550b6c-c690-4477-af72-5012dbf13397)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[CRT-6175]: https://toptal-core.atlassian.net/browse/CRT-6175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ