### PR TITLE
chore: [FX-4245] make URL input parameter optional

### DIFF
--- a/.changeset/hip-drinks-sip.md
+++ b/.changeset/hip-drinks-sip.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- make `environment-url` input parameter optional in `create-jira-deployment` GH Action

--- a/create-jira-deployment/README.md
+++ b/create-jira-deployment/README.md
@@ -13,7 +13,7 @@ The list of arguments, that are used in GH Action:
 | name                    | type   | required | default | description                                                                                                                                                                                                                                               |
 | ----------------------- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `token`                 | string | ✅        |         | GitHub token to create a deployment                                                                                                                                                                                                                       |
-| `environment-url`       | string | ✅        |         | URL of the environment                                                                                                                                                                                                                                    |
+| `environment-url`       | string |          |         | URL of the environment                                                                                                                                                                                                                                    |
 | `environment`           | string | ✅        |         | Name for the target deployment environment                                                                                                                                                                                                                |
 | `transient-environment` | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                                                                                                    |
 | `auto-inactive`         | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state. |
@@ -36,7 +36,7 @@ This is a list of ENV Variables that are used in GH Action:
 ### Usage
 
 ```yaml
-  - uses: toptal/davinci-github-actions/create-jira-deployment@v6.3.0
+  - uses: toptal/davinci-github-actions/create-jira-deployment@v9.1.1
     with:
       token: ${{ env.GITHUB_TOKEN }}
       environment: staging

--- a/create-jira-deployment/action.yml
+++ b/create-jira-deployment/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
     description: 'GitHub token to create a deployment'
   environment-url:
-    required: true
+    required: false
     description: 'URL of the environment'
   environment:
     required: true


### PR DESCRIPTION
[FX-4245]

### Description

make `environment-url` input parameter optional in `create-jira-deployment` GH Action

### How to test

- Use alpha version in existing GH Action

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4245]: https://toptal-core.atlassian.net/browse/FX-4245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ