### PR TITLE
chore: [FX-4328] make gh deployment optional

### DIFF
--- a/.changeset/stupid-grapes-sleep.md
+++ b/.changeset/stupid-grapes-sleep.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': major
+---
+
+- make GH Deployment optional in `create-jira-deployment` GH Action. By default this feature is disabled

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,22 +60,3 @@ jobs:
 
       - name: trufflehog-actions-scan
         uses: edplato/trufflehog-actions-scan@v0.9l-beta
-
-  test:
-    name: Test Alpha Release
-    runs-on: ubuntu-latest
-    env:
-      DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
-      JENKINS_USER: ${{ secrets.TOPTAL_TRIGGERBOT_USERNAME }}
-      JENKINS_BUILD_TOKEN: ${{ secrets.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
-      PROXY: http://${{ secrets.HTTP_PROXY }}
-    steps:
-      - name: Create Jira Deployment
-        uses: toptal/davinci-github-actions/create-jira-deployment@fx-4328-add-parameter-to-jira-deployments
-        with:
-          token: ${{ env.DEVBOT_TOKEN }}
-          environment: staging
-          environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}
-          transient-environment: false
-          auto-inactive: false
-          create-gh-deployment: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,3 +78,4 @@ jobs:
           environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}
           transient-environment: false
           auto-inactive: false
+          create-gh-deployment: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,3 +60,18 @@ jobs:
 
       - name: trufflehog-actions-scan
         uses: edplato/trufflehog-actions-scan@v0.9l-beta
+
+  test:
+    name: Test Alpha Release
+    runs-on: ubuntu-latest
+    env:
+      DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+    steps:
+      - name: Create Jira Deployment
+        uses: toptal/davinci-github-actions/create-jira-deployment@fx-4328-add-parameter-to-jira-deployments
+        with:
+          token: ${{ env.DEVBOT_TOKEN }}
+          environment: staging
+          environment-url: https://github.com/toptal/davinci-github-actions/releases/tag/${{ steps.tag-version.outputs.LATEST_TAG }}
+          transient-environment: false
+          auto-inactive: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+      JENKINS_USER: ${{ secrets.TOPTAL_TRIGGERBOT_USERNAME }}
+      JENKINS_BUILD_TOKEN: ${{ secrets.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+      PROXY: http://${{ secrets.HTTP_PROXY }}
     steps:
       - name: Create Jira Deployment
         uses: toptal/davinci-github-actions/create-jira-deployment@fx-4328-add-parameter-to-jira-deployments

--- a/create-jira-deployment/README.md
+++ b/create-jira-deployment/README.md
@@ -17,6 +17,7 @@ The list of arguments, that are used in GH Action:
 | `environment`           | string | ✅        |         | Name for the target deployment environment                                                                                                                                                                                                                |
 | `transient-environment` | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                                                                                                    |
 | `auto-inactive`         | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state. |
+| `create-gh-deployment`  | string |          | false   | Creates a Github Deployment along with JIRA Deployment                                                                                                                                                                                                    |
 
 ### Outputs
 
@@ -36,7 +37,7 @@ This is a list of ENV Variables that are used in GH Action:
 ### Usage
 
 ```yaml
-  - uses: toptal/davinci-github-actions/create-jira-deployment@v9.1.1
+  - uses: toptal/davinci-github-actions/create-jira-deployment@v10.0.0
     with:
       token: ${{ env.GITHUB_TOKEN }}
       environment: staging

--- a/create-jira-deployment/action.yml
+++ b/create-jira-deployment/action.yml
@@ -25,6 +25,11 @@ inputs:
     required: false
     description: Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state.
     default: 'true'
+  create-gh-deployment:
+    required: false
+    default: 'false'
+    description: Creates a Github Deployment along with JIRA Deployment
+
 
 runs:
   using: composite
@@ -32,7 +37,7 @@ runs:
     - uses: chrnorm/deployment-action@v2
       name: Create GitHub deployment
       id: gh-deployment
-      if: ${{ always() }}
+      if: ${{ always() && inputs.create-gh-deployment == 'true' }}
       with:
         token: ${{ inputs.token }}
         environment-url: ${{ inputs.environment-url }}
@@ -41,7 +46,7 @@ runs:
         auto-inactive: ${{ inputs.auto-inactive }}
 
     - name: Update deployment status on success
-      if: ${{ success() }}
+      if: ${{ success() && inputs.create-gh-deployment == 'true' }}
       uses: chrnorm/deployment-status@v2
       with:
         token: ${{ inputs.token }}
@@ -51,7 +56,7 @@ runs:
         state: 'success'
 
     - name: Update deployment status on failure
-      if: ${{ failure() }}
+      if: ${{ failure() && inputs.create-gh-deployment == 'true' }}
       uses: chrnorm/deployment-status@v2
       with:
         token: ${{ inputs.token }}


### PR DESCRIPTION
[FX-4328]

### Description

make **GH** Deployment optional in `create-jira-deployment` **GH** Action. By default this feature is **disabled**


### How to test

- Use branch version in Picasso PR to test

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4328]: https://toptal-core.atlassian.net/browse/FX-4328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ