### PR TITLE
chore: [FX-4406] bump node version to 18

### DIFF
--- a/.changeset/slimy-elephants-impress.md
+++ b/.changeset/slimy-elephants-impress.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': major
+---
+
+- bump node version to 18

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,10 +40,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 18.x
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: ./yarn-install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: ./yarn-install
 

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 16
+        node-version: 18
 
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 16
+        node-version: 18
 
     - id: meta-latest
       shell: bash

--- a/create-matrix/action.yml
+++ b/create-matrix/action.yml
@@ -19,5 +19,5 @@ outputs:
     description: Information about current repository || boolean
 
 runs:
-  using: node16
+  using: node18
   main: dist/index.js

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}

--- a/get-changeset-info/action.yml
+++ b/get-changeset-info/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: Packages that have changed but are missing in changesets || Array<string>
 
 runs:
-  using: node16
+  using: node18
   main: dist/index.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "author": "Toptal",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "documentation:generate": "ncc run _scripts/documentation/generate.ts -C",
     "release": "changeset tag",

--- a/report-affected-packages/action.yml
+++ b/report-affected-packages/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3.2.0
       with:
-        node-version: 16
+        node-version: 18
 
     - uses: masesgroup/retrieve-changed-files@2e42889ff54e0810cf088f73a38a2db5a9d0684f
       id: files


### PR DESCRIPTION
[FX-4406]

### Description

Bump node version in project to 18

### How to test

- Check alpha version in Picasso (https://github.com/toptal/picasso/pull/3920)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4406]: https://toptal-core.atlassian.net/browse/FX-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ