### PR TITLE
feat: change default value of docker-file parameter

### DIFF
--- a/.changeset/spicy-ears-share.md
+++ b/.changeset/spicy-ears-share.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': major
+---
+
+- change default value of `docker-file` parameter in `davinci-github-actions/build-push-image` action

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -12,14 +12,14 @@ This GH Action builds a Docker image and pushes to google cloud.
 
 The list of arguments, that are used in GH Action:
 
-| name             | type                                                        | required | default | description                                                                                |
-| ---------------- | ----------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------ |
-| `sha`            | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image                                |
-| `image-name`     | string                                                      | ✅        |         | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
-| `build-args`     | string                                                      | ✅        |         | Multiline string to describe build arguments that will be used during dockerization        |
-| `docker-file`    | string                                                      | ✅        |         | pathname to Docker file                                                                    |
-| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Determines additional procedures while creating a Docker image.                            |
-| `davinci-branch` | string                                                      |          | master  | Custom davinci branch                                                                      |
+| name             | type                                                        | required | default                                                        | description                                                                                |
+| ---------------- | ----------------------------------------------------------- | -------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `sha`            | string                                                      | ✅        |                                                                | Commit hash that will be used as a tag for the Docker image                                |
+| `image-name`     | string                                                      | ✅        |                                                                | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
+| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                                        | Determines additional procedures while creating a Docker image.                            |
+| `build-args`     | string                                                      | ✅        |                                                                | Multiline string to describe build arguments that will be used during dockerization        |
+| `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy | pathname to Docker file                                                                    |
+| `davinci-branch` | string                                                      |          | master                                                         | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -12,14 +12,14 @@ This GH Action builds a Docker image and pushes to google cloud.
 
 The list of arguments, that are used in GH Action:
 
-| name             | type                                                        | required | default                                             | description                                                                                |
-| ---------------- | ----------------------------------------------------------- | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `sha`            | string                                                      | ✅        |                                                     | Commit hash that will be used as a tag for the Docker image                                |
-| `image-name`     | string                                                      | ✅        |                                                     | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
-| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                             | Determines additional procedures while creating a Docker image.                            |
-| `build-args`     | string                                                      | ✅        |                                                     | Multiline string to describe build arguments that will be used during dockerization        |
-| `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile | pathname to Docker file                                                                    |
-| `davinci-branch` | string                                                      |          | master                                              | Custom davinci branch                                                                      |
+| name             | type                                                        | required | default | description                                                                                |
+| ---------------- | ----------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------ |
+| `sha`            | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image                                |
+| `image-name`     | string                                                      | ✅        |         | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
+| `build-args`     | string                                                      | ✅        |         | Multiline string to describe build arguments that will be used during dockerization        |
+| `docker-file`    | string                                                      | ✅        |         | pathname to Docker file                                                                    |
+| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Determines additional procedures while creating a Docker image.                            |
+| `davinci-branch` | string                                                      |          | master  | Custom davinci branch                                                                      |
 
 ### Outputs
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -13,17 +13,16 @@ inputs:
   image-name:
     required: true
     description: 'Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image)'
-  environment:
-    required: false
-    default: staging
-    description: 'Determines additional procedures while creating a Docker image. || enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>>'
   build-args:
     required: true
     description: 'Multiline string to describe build arguments that will be used during dockerization'
   docker-file:
     description: 'pathname to Docker file'
+    required: true
+  environment:
     required: false
-    default: ./davinci/packages/ci/src/configs/docker/Dockerfile
+    default: staging
+    description: 'Determines additional procedures while creating a Docker image. || enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>>'
   davinci-branch:
     description: 'Custom davinci branch'
     required: false

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -13,16 +13,17 @@ inputs:
   image-name:
     required: true
     description: 'Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image)'
+  environment:
+    required: false
+    default: staging
+    description: 'Determines additional procedures while creating a Docker image. || enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>>'
   build-args:
     required: true
     description: 'Multiline string to describe build arguments that will be used during dockerization'
   docker-file:
     description: 'pathname to Docker file'
-    required: true
-  environment:
     required: false
-    default: staging
-    description: 'Determines additional procedures while creating a Docker image. || enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>>'
+    default: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
   davinci-branch:
     description: 'Custom davinci branch'
     required: false


### PR DESCRIPTION
[FX-4401]

### Description

As a follow-up of https://github.com/toptal/davinci/pull/2166, `davinci-github-actions/build-push-image` action now has `docker-file` parameter changed (the old Dockerfile is deleted from `davinci-ci`)

### How to test

- Configuration update, all checks should pass

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4401]: https://toptal-core.atlassian.net/browse/FX-4401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ