### PR TITLE
Fix the yarn cache dir retrieval if no NPM_TOKEN is available in env

### DIFF
--- a/.changeset/great-beers-hammer.md
+++ b/.changeset/great-beers-hammer.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- fix `yarn cache dir` crash when no NPM_TOKEN env variable is available in the job

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -34,6 +34,8 @@ runs:
       id: yarn-cache
       run: echo dir=$(yarn cache dir) >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
 
     # This step is needed only because we want to update the cache when a new workspace
     # package has been added and we want symlinks to be presented in ./node_modules folder


### PR DESCRIPTION
### Description

The action accepts npm-token as a param or expects `NPM_TOKEN` env variable to exist in the job context. 

When the `NPM_TOKEN` variable exists, the job works like a charm 👍 

However, when the `NPM_TOKEN` variable doesn't exist, the `yarn cache dir` call breaks if the repository has a `.npmrc` file expecting `NPM_TOKEN` to exist

![Screenshot 2023-10-26 at 14 46 21](https://github.com/toptal/davinci-github-actions/assets/2437969/87c003cb-f3a1-429f-8ce4-c5f9fa8f3ea4)


### How to test

- Use this action in a workflow that doesn't have NPM_TOKEN var available (like [this](https://github.com/toptal/talent-portal-frontend/actions/workflows/library-snapshot.yml)) and see no error


| Branch | Workflow |
| --- | --- |
| https://github.com/toptal/talent-portal-frontend/compare/test-davinci-gha-224?expand=1 | https://github.com/toptal/talent-portal-frontend/actions/runs/6658308486/job/18094860780  |

The error is gone
<img width="1315" alt="Screenshot 2023-10-26 at 20 37 25" src="https://github.com/toptal/davinci-github-actions/assets/2437969/d3b640bd-ed84-4e80-a632-bb55cacb659e">


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
