### PR TITLE
[FX-4409] Add github action for renaming PRs from conventional commits to Toptal commits

### DIFF
--- a/.changeset/rude-goats-chew.md
+++ b/.changeset/rude-goats-chew.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add action for renaming PR titles from conventional commits to Toptal's commits, useful for renaming dependabot PRs

--- a/pr-conventional-to-toptal-commits/README.md
+++ b/pr-conventional-to-toptal-commits/README.md
@@ -17,3 +17,17 @@ Not specified
 Not specified
 
 ### Usage
+
+Formatting dependabot commit messages:
+
+```yaml
+on:
+  pull_request:
+    types: [opened]
+    branches: [master]
+
+jobs:
+  format_title:
+    if: startsWith(github.head_ref, 'dependabot-')
+    uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits
+```

--- a/pr-conventional-to-toptal-commits/README.md
+++ b/pr-conventional-to-toptal-commits/README.md
@@ -6,7 +6,11 @@ Convert a PR title from conventional commits to Toptal commit
 
 ### Inputs
 
-Not specified
+The list of arguments, that are used in GH Action:
+
+| name           | type   | required | default | description       |
+| -------------- | ------ | -------- | ------- | ----------------- |
+| `github-token` | string | ✅        |         | Github user token |
 
 ### Outputs
 
@@ -21,6 +25,7 @@ Not specified
 Formatting dependabot commit messages:
 
 ```yaml
+name: Format dependabot PR title to Toptal's commit convention
 on:
   pull_request:
     types: [opened]
@@ -28,8 +33,11 @@ on:
 
 jobs:
   format_title:
+    name: Format title
     if: startsWith(github.head_ref, 'dependabot-')
-    runs-on: ['org/toptal', 'os/linux', 'arch/x64', 'size/large']
+    runs-on: ['org/toptal', 'os/linux', 'arch/x64', 'size/large', 'ubuntu-latest']
     steps:
       - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits
+        with:
+          github-token: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
 ```

--- a/pr-conventional-to-toptal-commits/README.md
+++ b/pr-conventional-to-toptal-commits/README.md
@@ -1,0 +1,19 @@
+## PR Conventional to Toptal Commit
+
+Convert a PR title from conventional commits to Toptal commit
+
+### Description
+
+### Inputs
+
+Not specified
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+Not specified
+
+### Usage

--- a/pr-conventional-to-toptal-commits/README.md
+++ b/pr-conventional-to-toptal-commits/README.md
@@ -29,5 +29,7 @@ on:
 jobs:
   format_title:
     if: startsWith(github.head_ref, 'dependabot-')
-    uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits
+    runs-on: ['org/toptal', 'os/linux', 'arch/x64', 'size/large']
+    steps:
+      - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits
 ```

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -1,0 +1,31 @@
+name: PR Conventional to Toptal Commit
+description: Convert a PR title from conventional commits to Toptal commit
+
+runs:
+  using: composite
+  steps:
+    - name: Extract Env variables
+      id: env-variables
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github-token }}
+        result-encoding: string
+        script: |
+          const capitalize = (str) => (str[0] ?? '').toUpperCase() + str.slice(1)
+          const convertConventional = (title) => {
+            const pattern = /^\w+(?:\(.+\))?: (.*)$/
+            const [, titleMessage = ''] = title.match(pattern) ?? []
+
+            return capitalize(titleMessage.trim()) ?? title
+          }
+
+          const newPr = {
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            pull_number: github.context.payload.pull_request.number,
+            title: convertConventional(github.context.payload.pull_request.title)
+          }
+
+          octokit.pulls.update(newPr);
+
+

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -1,6 +1,11 @@
 name: PR Conventional to Toptal Commit
 description: Convert a PR title from conventional commits to Toptal commit
 
+inputs:
+  github-token:
+    required: true
+    description: Github user token
+
 runs:
   using: composite
   steps:
@@ -20,12 +25,12 @@ runs:
           }
 
           const newPr = {
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            pull_number: github.context.payload.pull_request.number,
-            title: convertConventional(github.context.payload.pull_request.title)
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            title: convertConventional(context.payload.pull_request.title)
           }
 
-          octokit.pulls.update(newPr);
+          github.rest.pulls.update(newPr);
 
 


### PR DESCRIPTION
[FX-4409]

### Description

Add github action for renaming PRs from conventional commits to Toptal commits

### How to test

- Test action on a private project
- See action run https://github.com/toptal/picasso/actions/runs/6858936980/job/18650460858?pr=3980 and event https://github.com/toptal/picasso/pull/3980#event-10949429751

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4409]: https://toptal-core.atlassian.net/browse/FX-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ