### PR TITLE
Add node-version parameters

### DIFF
--- a/.changeset/funny-cameras-doubt.md
+++ b/.changeset/funny-cameras-doubt.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add option of specifying the version of Node.js used for some of the actions (`build-publish-alpha-package`, `build-push-image`, `deploy-storybook`, `report-affected-packages`)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup Node.js 18.x
+      - name: Set up Node.js 18.x
         uses: actions/setup-node@v3.8.1
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           # This forces changesets to use git user, provided by GITHUB_TOKEN env var
           persist-credentials: false
 
-      - name: Setup node
+      - name: Set up node
         uses: actions/setup-node@v3.8.1
         with:
           node-version: 18

--- a/build-publish-alpha-package/README.md
+++ b/build-publish-alpha-package/README.md
@@ -14,11 +14,12 @@ Uses `yarn build:package` command to build the package.
 
 The list of arguments, that are used in GH Action:
 
-| name          | type   | required | default | description                                           |
-| ------------- | ------ | -------- | ------- | ----------------------------------------------------- |
-| `npm-token`   | string | ✅        |         | NPM token used for publishing. Has to be type Publish |
-| `branch`      | string | ✅        |         | Name of the branch that will be published             |
-| `root-folder` | string |          |         | Root folder of a package to be published              |
+| name           | type   | required | default | description                                                                                 |
+| -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------- |
+| `npm-token`    | string | ✅        |         | NPM token used for publishing. Has to be type Publish                                       |
+| `branch`       | string | ✅        |         | Name of the branch that will be published                                                   |
+| `root-folder`  | string |          |         | Root folder of a package to be published                                                    |
+| `node-version` | string |          | 18      | Node.js version used. The action is guaranteed to work only with Node.js@18 (default value) |
 
 ### Outputs
 

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -15,6 +15,10 @@ inputs:
   root-folder:
     required: false
     description: 'Root folder of a package to be published || string'
+  node-version:
+    required: false
+    default: 18
+    description: 'Node.js version used. The action is guaranteed to work only with Node.js@18 (default value)'
 
 runs:
   using: composite
@@ -29,7 +33,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
 
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -30,7 +30,7 @@ runs:
       run: |
         npm set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
 
-    - name: Setup node
+    - name: Set up node
       uses: actions/setup-node@v3.2.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -12,14 +12,15 @@ This GH Action builds a Docker image and pushes to google cloud.
 
 The list of arguments, that are used in GH Action:
 
-| name             | type                                                        | required | default                                                        | description                                                                                |
-| ---------------- | ----------------------------------------------------------- | -------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `sha`            | string                                                      | ✅        |                                                                | Commit hash that will be used as a tag for the Docker image                                |
-| `image-name`     | string                                                      | ✅        |                                                                | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
-| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                                        | Determines additional procedures while creating a Docker image.                            |
-| `build-args`     | string                                                      | ✅        |                                                                | Multiline string to describe build arguments that will be used during dockerization        |
-| `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy | pathname to Docker file                                                                    |
-| `davinci-branch` | string                                                      |          | master                                                         | Custom davinci branch                                                                      |
+| name             | type                                                        | required | default                                                        | description                                                                                 |
+| ---------------- | ----------------------------------------------------------- | -------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `sha`            | string                                                      | ✅        |                                                                | Commit hash that will be used as a tag for the Docker image                                 |
+| `image-name`     | string                                                      | ✅        |                                                                | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image)  |
+| `environment`    | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging                                                        | Determines additional procedures while creating a Docker image.                             |
+| `build-args`     | string                                                      | ✅        |                                                                | Multiline string to describe build arguments that will be used during dockerization         |
+| `docker-file`    | string                                                      |          | ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy | pathname to Docker file                                                                     |
+| `davinci-branch` | string                                                      |          | master                                                         | Custom davinci branch                                                                       |
+| `node-version`   | string                                                      |          | 18                                                             | Node.js version used. The action is guaranteed to work only with Node.js@18 (default value) |
 
 ### Outputs
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout davinci
+    - name: Check out davinci
       uses: actions/checkout@v3
       with:
         repository: toptal/davinci
@@ -44,7 +44,7 @@ runs:
         path: davinci
         ref: ${{ inputs.davinci-branch }}
 
-    - name: Setup node
+    - name: Set up node
       uses: actions/setup-node@v3.2.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -49,6 +49,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    # TODO: remove before merge
+    - name: Check version
+      run: yarn node --version
+
     - id: meta-latest
       shell: bash
       env:

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Custom davinci branch'
     required: false
     default: 'master'
+  node-version:
+    required: false
+    default: 18
+    description: 'Node.js version used. The action is guaranteed to work only with Node.js@18 (default value)'
 
 runs:
   using: composite
@@ -43,7 +47,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3.2.0
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
 
     - id: meta-latest
       shell: bash

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -49,11 +49,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    # TODO: remove before merge
-    - name: Check version
-      shell: bash
-      run: yarn node --version
-
     - id: meta-latest
       shell: bash
       env:

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -51,6 +51,7 @@ runs:
 
     # TODO: remove before merge
     - name: Check version
+      shell: bash
       run: yarn node --version
 
     - id: meta-latest

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -10,20 +10,21 @@ Currently ENV variables for Storybook are not supported.
 
 The list of arguments, that are used in GH Action:
 
-| name                     | type                                       | required | default            | description                                                                             |
-| ------------------------ | ------------------------------------------ | -------- | ------------------ | --------------------------------------------------------------------------------------- |
-| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                             |
-| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                      |
-| `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only     |
-| `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                                   |
-| `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                                 |
-| `build-command`          | string                                     |          | storybook:build    | Command to build Storybook with                                                         |
-| `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                          |
-| `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                     |
-| `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                    |
-| `generate-types-command` | string                                     |          | false              | Command to generate gql types                                                           |
-| `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. . |
-| `checkout-token`         | string                                     |          |                    | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners       |
+| name                     | type                                       | required | default            | description                                                                                 |
+| ------------------------ | ------------------------------------------ | -------- | ------------------ | ------------------------------------------------------------------------------------------- |
+| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                                 |
+| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                          |
+| `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only         |
+| `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                                       |
+| `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                                     |
+| `build-command`          | string                                     |          | storybook:build    | Command to build Storybook with                                                             |
+| `use-prebuilt-package`   | string                                     |          | false              | If a prebuilt Storybook package should be used                                              |
+| `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                         |
+| `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                        |
+| `generate-types-command` | string                                     |          | false              | Command to generate gql types                                                               |
+| `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. .     |
+| `checkout-token`         | string                                     |          |                    | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners           |
+| `node-version`           | string                                     |          | 18                 | Node.js version used. The action is guaranteed to work only with Node.js@18 (default value) |
 
 ### Outputs
 

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -54,6 +54,10 @@ inputs:
   checkout-token:
     description: Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners
     required: false
+  node-version:
+    required: false
+    default: 18
+    description: 'Node.js version used. The action is guaranteed to work only with Node.js@18 (default value)'
 
 runs:
   using: composite
@@ -61,7 +65,7 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
 
     - name: Install Dependencies
       if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}

--- a/report-affected-packages/README.md
+++ b/report-affected-packages/README.md
@@ -8,7 +8,11 @@ Generate a diagram of affected monorepo packages. Works with worksflows triggere
 
 ### Inputs
 
-Not specified
+The list of arguments, that are used in GH Action:
+
+| name           | type   | required | default | description                                                                                 |
+| -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------- |
+| `node-version` | string |          | 18      | Node.js version used. The action is guaranteed to work only with Node.js@18 (default value) |
 
 ### Outputs
 

--- a/report-affected-packages/action.yml
+++ b/report-affected-packages/action.yml
@@ -1,12 +1,18 @@
 name: 'Report affected packages'
 description: 'Generate a diagram of affected monorepo packages as a job summary. Works with workflows triggered by pull_request event.'
 
+inputs:
+  node-version:
+    required: false
+    default: 18
+    description: 'Node.js version used. The action is guaranteed to work only with Node.js@18 (default value)'
+
 runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@v3.2.0
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
 
     - uses: masesgroup/retrieve-changed-files@2e42889ff54e0810cf088f73a38a2db5a9d0684f
       id: files


### PR DESCRIPTION
[FX-4432]

### Description

This pull request makes it possible to specify the version of Node.js used for 4 actions (that use the `actions/setup-node` inside).

### How to test

As an example, the https://github.com/toptal/davinci-github-actions/tree/master/build-push-image action is tested in Picasso repo in https://github.com/toptal/picasso/pull/3994

- When existing Node.js version is provided

<img width="457" alt="Screenshot 2023-11-17 at 18 40 37" src="https://github.com/toptal/davinci-github-actions/assets/1390758/0e6a2828-84c2-4741-83a1-d1fd3fd36640">

- When non-existing Node.js version is provided

<img width="1089" alt="Screenshot 2023-11-17 at 18 28 40" src="https://github.com/toptal/davinci-github-actions/assets/1390758/f249612e-aae6-4530-a973-d7c4628ed605">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4432]: https://toptal-core.atlassian.net/browse/FX-4432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ