### PR TITLE
Fix docs in pr-conventional-to-toptal-commits

### DIFF
--- a/pr-conventional-to-toptal-commits/README.md
+++ b/pr-conventional-to-toptal-commits/README.md
@@ -35,7 +35,7 @@ jobs:
   format_title:
     name: Format title
     if: startsWith(github.head_ref, 'dependabot-')
-    runs-on: ['org/toptal', 'os/linux', 'arch/x64', 'size/large', 'ubuntu-latest']
+    runs-on: ['org/toptal', 'os/linux', 'arch/x64', 'size/standard']
     steps:
       - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits
         with:


### PR DESCRIPTION
No Jira ticket.

### Description

Minor housekeeping, there is no 'ubuntu-latest' label for Toptal runners (https://toptal-core.atlassian.net/wiki/spaces/CI/pages/3135570011/GHA+custom+runners+-+labels#Template-for-labels-set)

### How to test

- Documentation change

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
