### PR TITLE
[FX-4380] Fix Storybook temploy link truncation

### DIFF
--- a/.changeset/clean-yaks-punch.md
+++ b/.changeset/clean-yaks-punch.md
@@ -1,0 +1,7 @@
+---
+'@toptal/davinci-github-actions': minor
+---
+
+### deploy-storybook
+
+- fixed storybook temploy link

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -172,7 +172,7 @@ runs:
         script: |
           const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 63))
+          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}'].join('-').substring(0, 63))
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.rest.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -172,7 +172,7 @@ runs:
         script: |
           const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}'].join('-').substring(0, 63))
+          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45))
           const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
           const number = issue_number || ${{ env.PR_NUMBER }}
           github.rest.issues.createComment({ issue_number: number, owner, repo, body })


### PR DESCRIPTION
[FX-4520](https://toptal-core.atlassian.net/browse/FX-4520)

### Description

Hostnames are actually truncated to 45 characters, not 63, acttording to our helm chart helpers.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4520]: https://toptal-core.atlassian.net/browse/FX-4520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ