### PR TITLE
[CI-2922] Update workflows to fetch secrets from GSM

### DIFF
--- a/.changeset/chilled-turkeys-exist.md
+++ b/.changeset/chilled-turkeys-exist.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- use GSM in workflows

--- a/.github/workflows/handle-contribution.yml
+++ b/.github/workflows/handle-contribution.yml
@@ -10,12 +10,33 @@ jobs:
   call-notify-jira-about-contribution:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      pull-requests: write
+      issues: write
     name: Call notify jira about contribution
     steps:
+      - name: GSM Secrets
+        id: secrets_manager
+        uses: toptal/davinci-github-actions/gsm-secrets@master
+        with:
+          workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
+          service_account: ${{ secrets.SA_IDENTITY_POOL }}
+          secrets_name: |-
+            DAVINCI_GITHUB_ACTIONS_JIRA_AUTOMATION_HOOK_FOR_NEW_CONTRIBUTION:toptal-ci/DAVINCI_GITHUB_ACTIONS_JIRA_AUTOMATION_HOOK_FOR_NEW_CONTRIBUTION
+            TOPTAL_DEVBOT_TOKEN:toptal-ci/TOPTAL_DEVBOT_TOKEN
+                
+      - name: Parse secrets
+        id: parse_secrets
+        uses: toptal/davinci-github-actions/expose-json-outputs@master
+        with:
+          json: ${{ steps.secrets_manager.outputs.secrets }}
       - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v12.0.0
         with:
           team: frontend-experience-eng
           repo: ${{ github.event.repository.name }}
           pull-number: ${{ github.event.pull_request.number}}
-          jira-hook: ${{ secrets.JIRA_AUTOMATION_HOOK_FOR_NEW_CONTRIBUTION }}
-          github-token: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+          jira-hook: ${{ steps.parse_secrets.outputs.DAVINCI_GITHUB_ACTIONS_JIRA_AUTOMATION_HOOK_FOR_NEW_CONTRIBUTION }}
+          github-token: ${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,17 @@ on:
       - master
 
 env:
-  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   GITHUB_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
-  JENKINS_USER: ${{ secrets.TOPTAL_TRIGGERBOT_USERNAME }}
-  JENKINS_BUILD_TOKEN: ${{ secrets.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
-  PROXY: http://${{ secrets.HTTP_PROXY }}
-
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4.1.0
@@ -26,6 +26,33 @@ jobs:
           # This forces changesets to use git user, provided by GITHUB_TOKEN env var
           persist-credentials: false
 
+      - name: GSM Secrets
+        id: secrets_manager
+        uses: toptal/davinci-github-actions/gsm-secrets@master
+        with:
+          workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
+          service_account: ${{ secrets.SA_IDENTITY_POOL }}
+          secrets_name: |-
+            HTTP_PROXY:toptal-ci/HTTP_PROXY
+            SLACK_BOT_TOKEN:toptal-ci/SLACK_BOT_TOKEN
+            TOPTAL_DEVBOT_TOKEN:toptal-ci/TOPTAL_DEVBOT_TOKEN
+            TOPTAL_TRIGGERBOT_BUILD_TOKEN:toptal-ci/TOPTAL_TRIGGERBOT_BUILD_TOKEN
+            TOPTAL_TRIGGERBOT_USERNAME:toptal-ci/TOPTAL_TRIGGERBOT_USERNAME
+                
+      - name: Parse secrets
+        id: parse_secrets
+        uses: toptal/davinci-github-actions/expose-json-outputs@master
+        with:
+          json: ${{ steps.secrets_manager.outputs.secrets }}
+
+      - name: Set ENV Variables
+        run: |-
+          echo "SLACK_BOT_TOKEN=${{ steps.parse_secrets.outputs.SLACK_BOT_TOKEN }}" >> $GITHUB_ENV
+          echo "DEVBOT_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}" >> $GITHUB_ENV
+          echo "JENKINS_USER=${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}" >> $GITHUB_ENV
+          echo "JENKINS_BUILD_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}" >> $GITHUB_ENV
+          echo "PROXY=${{ steps.parse_secrets.outputs.HTTP_PROXY }}" >> $GITHUB_ENV
+                  
       - name: Set up node
         uses: actions/setup-node@v3.8.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 .envrc
 
 anvil_test_results.json
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
[CI-2922](https://toptal-core.atlassian.net/browse/CI-2922)

### Description
CI Infrastructure is reaching the final stage of migrating all GitHub Action secrets to centralized secrets management solution: Google Secrets Manager ([here](https://toptal-core.slack.com/archives/C2W28V7L7/p1687258750273559) you can find the whole announcement). We create PRs in automatic way and the workflows are updated according to the [documentation](https://toptal-core.atlassian.net/wiki/spaces/CI/pages/3257139253/Google+Secret+Manager+-+Technical+Documentation#How-to-modify-the-GitHub-workflow-to-fetch-secrets-from-GSM). Each workflow is different, so we should test them and make adjustments if necessary.

The changes will not influence performance of the workflow execution.

### How to test
- run workflow(s)

### CI checklist:
- [x] all modified workflows were tested
- [x] check if the secrets were fetched from GSM correctly


[CI-2922]: https://toptal-core.atlassian.net/browse/CI-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ