### PR TITLE
[FX-3861] Update github actions versions

### DIFF
--- a/.changeset/olive-rings-help.md
+++ b/.changeset/olive-rings-help.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- update dependencies (`google-github-actions/*` and `docker/*`)

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4.3.0
+      uses: docker/metadata-action@v5.2.0
       with:
         images: |
           us-central1-docker.pkg.dev/toptal-hub/containers/${{ inputs.image-name }}
@@ -69,7 +69,7 @@ runs:
           latest=${{ steps.meta-latest.outputs.latest }}
 
     - name: Login to Google Artifact Registry - GAR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: us-central1-docker.pkg.dev
         username: _json_key
@@ -77,10 +77,10 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push release image
-      uses: docker/build-push-action@v3.3.0
+      uses: docker/build-push-action@v5.1.0
       with:
         provenance: false
         tags: ${{ steps.meta.outputs.tags }}

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -13,13 +13,13 @@ runs:
   using: composite
   steps:
     - name: Auth Google cloud toolchain
-      uses: google-github-actions/auth@v1.0.0
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ inputs.gcr-gql-schemas-bucket-token }}
         create_credentials_file: true
 
     - name: Setup Google cloud toolchain
-      uses: google-github-actions/setup-gcloud@v1.1.0
+      uses: google-github-actions/setup-gcloud@v1.1.1
 
     - name: Check types cache
       uses: actions/cache@v3

--- a/gsm-secrets/action.yml
+++ b/gsm-secrets/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - name: Authenticate to Google Cloud using WIF
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}


### PR DESCRIPTION
[FX-3861]

### Description

This pull request updates versions of `google-github-actions/*` `and docker/*` actions.

Asked for clarifications on using the major (floating) version tags for third-party GHA in https://toptal-core.slack.com/archives/CAR6HQ2K1/p1701372038502019, any follow-ups will be addressed in separate pull requests.

### How to test

- Updated actions are tested in https://github.com/toptal/picasso/pull/4038, all checks should pass

<img width="1132" alt="Screenshot 2023-12-01 at 12 13 03" src="https://github.com/toptal/davinci-github-actions/assets/1390758/fe351bcc-9564-47c7-ae70-059f0b2c7bd1">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)
- [x] ⚠️ **Close https://github.com/toptal/picasso/pull/4038**

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-3861]: https://toptal-core.atlassian.net/browse/FX-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ