### PR TITLE
[CI-3043] Switch to trigger-jenkins-job action

### DIFF
--- a/.changeset/little-beans-admire.md
+++ b/.changeset/little-beans-admire.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': major
+---
+
+- change the create-jira-deployment and deploy-storybook actions to use the trigger-jenkins-job actions that implements IAP. Please read the actions REAME.md files to check how to use them.

--- a/create-jira-deployment/README.md
+++ b/create-jira-deployment/README.md
@@ -11,34 +11,35 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 The list of arguments, that are used in GH Action:
 
 | name                    | type   | required | default | description                                                                                                                                                                                                                                               |
-| ----------------------- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `token`                 | string | ✅        |         | GitHub token to create a deployment                                                                                                                                                                                                                       |
-| `environment-url`       | string |          |         | URL of the environment                                                                                                                                                                                                                                    |
-| `environment`           | string | ✅        |         | Name for the target deployment environment                                                                                                                                                                                                                |
-| `transient-environment` | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                                                                                                    |
-| `auto-inactive`         | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state. |
-| `create-gh-deployment`  | string |          | false   | Creates a Github Deployment along with JIRA Deployment                                                                                                                                                                                                    |
+| ----------------------- | ------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jenkins_url`           | string | ✅       |         | Jenkins build instance                                                                                                                                                     |
+| `jenkins_user`          | string | ✅       |         | Jenkins build user                                                                                                                                                         |
+| `jenkins_token`         | string | ✅       |         | Jenkins build token                                                                                                                                                        |
+| `jenkins_client_id`     | string | ✅       |         | Jenkins Client ID used with IAP                                                                                                                                            |
+| `jenkins_sa_credentials`| string | ✅       |         | Jenkins service account credentials to use with IAP                                                                                                                        |
+| `token`                 | string | ✅       |         | GitHub token to create a deployment                                                                                                                                        |
+| `environment-url`       | string |          |         | URL of the environment                                                                                                                                                     |
+| `environment`           | string | ✅       |         | Name for the target deployment environment                                                                                                                                 |
+| `transient-environment` | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                     |
+| `auto-inactive`         | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's        |
+|                         |        |          |         | deployment. An inactive status is only added to deployments that had a success state.                                                                                      |
+| `create-gh-deployment`  | string |          | false   | Creates a Github Deployment along with JIRA Deployment                                                                                                                     |
 
 ### Outputs
 
 Not specified
-
-### ENV Variables
-
-All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
-This is a list of ENV Variables that are used in GH Action:
-
-| name                  | description                                                                      |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `JENKINS_USER`        | Jenkins user                                                                     |
-| `JENKINS_BUILD_TOKEN` | Jenkins build token. Keep in mind that tokens for `temploy` and `staging` differ |
-| `PROXY`               | Proxy to use for Jenkins                                                         |
+                                                        |
 
 ### Usage
 
 ```yaml
   - uses: toptal/davinci-github-actions/create-jira-deployment@v10.0.0
     with:
+      jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
+      jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
+      jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+      jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
+      jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
       token: ${{ env.GITHUB_TOKEN }}
       environment: staging
       environment-url: http://staging.example.com

--- a/create-jira-deployment/README.md
+++ b/create-jira-deployment/README.md
@@ -10,25 +10,23 @@ Installs package dependencies. Caches `node_modules` for faster subsequent insta
 
 The list of arguments, that are used in GH Action:
 
-| name                    | type   | required | default | description                                                                                                                                                                                                                                               |
-| ----------------------- | ------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `jenkins_url`           | string | ✅       |         | Jenkins build instance                                                                                                                                                     |
-| `jenkins_user`          | string | ✅       |         | Jenkins build user                                                                                                                                                         |
-| `jenkins_token`         | string | ✅       |         | Jenkins build token                                                                                                                                                        |
-| `jenkins_client_id`     | string | ✅       |         | Jenkins Client ID used with IAP                                                                                                                                            |
-| `jenkins_sa_credentials`| string | ✅       |         | Jenkins service account credentials to use with IAP                                                                                                                        |
-| `token`                 | string | ✅       |         | GitHub token to create a deployment                                                                                                                                        |
-| `environment-url`       | string |          |         | URL of the environment                                                                                                                                                     |
-| `environment`           | string | ✅       |         | Name for the target deployment environment                                                                                                                                 |
-| `transient-environment` | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                     |
-| `auto-inactive`         | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's        |
-|                         |        |          |         | deployment. An inactive status is only added to deployments that had a success state.                                                                                      |
-| `create-gh-deployment`  | string |          | false   | Creates a Github Deployment along with JIRA Deployment                                                                                                                     |
+| name                     | type   | required | default | description                                                                                                                                                                                                                                               |
+| ------------------------ | ------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jenkins_url`            | string | ✅        |         | Jenkins build instance URL                                                                                                                                                                                                                                |
+| `jenkins_user`           | string | ✅        |         | Jenkins build user                                                                                                                                                                                                                                        |
+| `jenkins_token`          | string | ✅        |         | Jenkins build token                                                                                                                                                                                                                                       |
+| `jenkins_client_id`      | string | ✅        |         | Jenkins Client ID used with IAP                                                                                                                                                                                                                           |
+| `jenkins_sa_credentials` | string | ✅        |         | Jenkins service account credentials to use with IAP                                                                                                                                                                                                       |
+| `token`                  | string | ✅        |         | GitHub token to create a deployment                                                                                                                                                                                                                       |
+| `environment-url`        | string |          |         | URL of the environment                                                                                                                                                                                                                                    |
+| `environment`            | string | ✅        |         | Name for the target deployment environment                                                                                                                                                                                                                |
+| `transient-environment`  | string |          | true    | Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.                                                                                                                                    |
+| `auto-inactive`          | string |          | true    | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state. |
+| `create-gh-deployment`   | string |          | false   | Creates a Github Deployment along with JIRA Deployment                                                                                                                                                                                                    |
 
 ### Outputs
 
 Not specified
-                                                        |
 
 ### Usage
 

--- a/create-jira-deployment/action.yml
+++ b/create-jira-deployment/action.yml
@@ -43,46 +43,46 @@ inputs:
 runs:
   using: composite
   steps:
-    # - uses: chrnorm/deployment-action@v2
-    #   name: Create GitHub deployment
-    #   id: gh-deployment
-    #   if: ${{ always() && inputs.create-gh-deployment == 'true' }}
-    #   with:
-    #     token: ${{ inputs.token }}
-    #     environment-url: ${{ inputs.environment-url }}
-    #     environment: ${{ inputs.environment }}
-    #     transient-environment: ${{ inputs.transient-environment }}
-    #     auto-inactive: ${{ inputs.auto-inactive }}
+    - uses: chrnorm/deployment-action@v2
+      name: Create GitHub deployment
+      id: gh-deployment
+      if: ${{ always() && inputs.create-gh-deployment == 'true' }}
+      with:
+        token: ${{ inputs.token }}
+        environment-url: ${{ inputs.environment-url }}
+        environment: ${{ inputs.environment }}
+        transient-environment: ${{ inputs.transient-environment }}
+        auto-inactive: ${{ inputs.auto-inactive }}
 
-    # - name: Update deployment status on success
-    #   if: ${{ success() && inputs.create-gh-deployment == 'true' }}
-    #   uses: chrnorm/deployment-status@v2
-    #   with:
-    #     token: ${{ inputs.token }}
-    #     environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
-    #     deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
-    #     log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    #     state: 'success'
+    - name: Update deployment status on success
+      if: ${{ success() && inputs.create-gh-deployment == 'true' }}
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: ${{ inputs.token }}
+        environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
+        deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
+        log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        state: 'success'
 
-    # - name: Update deployment status on failure
-    #   if: ${{ failure() && inputs.create-gh-deployment == 'true' }}
-    #   uses: chrnorm/deployment-status@v2
-    #   with:
-    #     token: ${{ inputs.token }}
-    #     environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
-    #     deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
-    #     log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    #     state: 'failure'
+    - name: Update deployment status on failure
+      if: ${{ failure() && inputs.create-gh-deployment == 'true' }}
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: ${{ inputs.token }}
+        environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
+        deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
+        log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        state: 'failure'
 
-    # - name: Set appName
-    #   id: repo
-    #   if: ${{ always() }}
-    #   shell: bash
-    #   run: |
-    #     echo APP_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2) >> $GITHUB_OUTPUT
+    - name: Set appName
+      id: repo
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        echo APP_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2) >> $GITHUB_OUTPUT
 
-    # - id: sha
-    #   uses: toptal/davinci-github-actions/get-workflow-sha@master
+    - id: sha
+      uses: toptal/davinci-github-actions/get-workflow-sha@master
 
     - name: Trigger `Create JIRA` deployment
       uses: toptal/actions/trigger-jenkins-job@main
@@ -93,12 +93,11 @@ runs:
         jenkins_token: ${{ inputs.jenkins_token }}
         jenkins_client_id: ${{ inputs.jenkins_client_id }}
         jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
-        # job_name: create-jira-deployment
-        # job_params: |
-        #   {
-        #     "appName": "${{ steps.repo.outputs.APP_NAME }}",
-        #     "envName": "${{ inputs.environment }}",
-        #     "sha": "${{ github.event.pull_request.head.sha || steps.sha.outputs.result }}"
-        #   }
-        job_name: job-test-iap
+        job_name: create-jira-deployment
+        job_params: |
+          {
+            "appName": "${{ steps.repo.outputs.APP_NAME }}",
+            "envName": "${{ inputs.environment }}",
+            "sha": "${{ github.event.pull_request.head.sha || steps.sha.outputs.result }}"
+          }
         job_timeout: '3600'

--- a/create-jira-deployment/action.yml
+++ b/create-jira-deployment/action.yml
@@ -1,13 +1,23 @@
 name: Create new Jira Deployment
 description: |
   It creates and engages a new Jira Deployment. Notice: Jira App must be installed in the repository.
-  ****
-  envInputs:
-    JENKINS_USER: Jenkins user
-    JENKINS_BUILD_TOKEN: Jenkins build token. Keep in mind that tokens for `temploy` and `staging` differ
-    PROXY: Proxy to use for Jenkins
 
 inputs:
+  jenkins_url:
+    description: 'Jenkins build instance URL'
+    required: true
+  jenkins_user:
+    description: 'Jenkins build user'
+    required: true
+  jenkins_token:
+    description: 'Jenkins build token'
+    required: true
+  jenkins_client_id:
+    description: 'Jenkins Client ID used with IAP'
+    required: true
+  jenkins_sa_credentials:
+    description: 'Jenkins service account credentials to use with IAP'
+    required: true
   token:
     required: true
     description: 'GitHub token to create a deployment'
@@ -30,64 +40,65 @@ inputs:
     default: 'false'
     description: Creates a Github Deployment along with JIRA Deployment
 
-
 runs:
   using: composite
   steps:
-    - uses: chrnorm/deployment-action@v2
-      name: Create GitHub deployment
-      id: gh-deployment
-      if: ${{ always() && inputs.create-gh-deployment == 'true' }}
-      with:
-        token: ${{ inputs.token }}
-        environment-url: ${{ inputs.environment-url }}
-        environment: ${{ inputs.environment }}
-        transient-environment: ${{ inputs.transient-environment }}
-        auto-inactive: ${{ inputs.auto-inactive }}
+    # - uses: chrnorm/deployment-action@v2
+    #   name: Create GitHub deployment
+    #   id: gh-deployment
+    #   if: ${{ always() && inputs.create-gh-deployment == 'true' }}
+    #   with:
+    #     token: ${{ inputs.token }}
+    #     environment-url: ${{ inputs.environment-url }}
+    #     environment: ${{ inputs.environment }}
+    #     transient-environment: ${{ inputs.transient-environment }}
+    #     auto-inactive: ${{ inputs.auto-inactive }}
 
-    - name: Update deployment status on success
-      if: ${{ success() && inputs.create-gh-deployment == 'true' }}
-      uses: chrnorm/deployment-status@v2
-      with:
-        token: ${{ inputs.token }}
-        environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
-        deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
-        log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        state: 'success'
+    # - name: Update deployment status on success
+    #   if: ${{ success() && inputs.create-gh-deployment == 'true' }}
+    #   uses: chrnorm/deployment-status@v2
+    #   with:
+    #     token: ${{ inputs.token }}
+    #     environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
+    #     deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
+    #     log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    #     state: 'success'
 
-    - name: Update deployment status on failure
-      if: ${{ failure() && inputs.create-gh-deployment == 'true' }}
-      uses: chrnorm/deployment-status@v2
-      with:
-        token: ${{ inputs.token }}
-        environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
-        deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
-        log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        state: 'failure'
+    # - name: Update deployment status on failure
+    #   if: ${{ failure() && inputs.create-gh-deployment == 'true' }}
+    #   uses: chrnorm/deployment-status@v2
+    #   with:
+    #     token: ${{ inputs.token }}
+    #     environment-url: ${{ steps.gh-deployment.outputs.environment_url }}
+    #     deployment-id: ${{ steps.gh-deployment.outputs.deployment_id }}
+    #     log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    #     state: 'failure'
 
-    - name: Set appName
-      id: repo
-      if: ${{ always() }}
-      shell: bash
-      run: |
-        echo APP_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2) >> $GITHUB_OUTPUT
+    # - name: Set appName
+    #   id: repo
+    #   if: ${{ always() }}
+    #   shell: bash
+    #   run: |
+    #     echo APP_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2) >> $GITHUB_OUTPUT
 
-    - id: sha
-      uses: toptal/davinci-github-actions/get-workflow-sha@master
+    # - id: sha
+    #   uses: toptal/davinci-github-actions/get-workflow-sha@master
 
     - name: Trigger `Create JIRA` deployment
-      uses: toptal/jenkins-job-trigger-action@1.0.1
+      uses: toptal/actions/trigger-jenkins-job@main
       if: ${{ always() }}
       with:
-        jenkins_url: https://jenkins-build.toptal.net/
-        jenkins_user: ${{ env.JENKINS_USER }}
-        jenkins_token: ${{ env.JENKINS_BUILD_TOKEN }}
-        proxy: ${{ env.PROXY }}
-        job_name: create-jira-deployment
-        job_params: |
-          {
-            "appName": "${{ steps.repo.outputs.APP_NAME }}",
-            "envName": "${{ inputs.environment }}",
-            "sha": "${{ github.event.pull_request.head.sha || steps.sha.outputs.result }}"
-          }
+        jenkins_url: ${{ inputs.jenkins_url }}
+        jenkins_user: ${{ inputs.jenkins_user }}
+        jenkins_token: ${{ inputs.jenkins_token }}
+        jenkins_client_id: ${{ inputs.jenkins_client_id }}
+        jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
+        # job_name: create-jira-deployment
+        # job_params: |
+        #   {
+        #     "appName": "${{ steps.repo.outputs.APP_NAME }}",
+        #     "envName": "${{ inputs.environment }}",
+        #     "sha": "${{ github.event.pull_request.head.sha || steps.sha.outputs.result }}"
+        #   }
+        job_name: job-test-iap
         job_timeout: '3600'

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -12,13 +12,13 @@ The list of arguments, that are used in GH Action:
 
 | name                     | type                                       | required | default            | description                                                                                 |
 | ------------------------ | ------------------------------------------ | -------- | ------------------ | ------------------------------------------------------------------------------------------- |
-| `jenkins_url`            | string                                     | ✅       |                    | Jenkins instance URL                                                                        |
-| `jenkins_user`           | string                                     | ✅       |                    | Jenkins user                                                                                |
-| `jenkins_token`          | string                                     | ✅       |                    | Jenkins token                                                                               |
-| `jenkins_client_id`      | string                                     | ✅       |                    | Jenkins Client ID used with IAP                                                             |
-| `jenkins_sa_credentials` | string                                     | ✅       |                    | Jenkins service account credentials to use with IAP                                         |
-| `sha`                    | string                                     | ✅       |                    | Commit hash that will be used as a tag for the Docker image                                 |
-| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅       |                    | Environment to deploy Storybook to                                                          |
+| `jenkins_url`            | string                                     | ✅        |                    | Jenkins main instance URL                                                                   |
+| `jenkins_user`           | string                                     | ✅        |                    | Jenkins user                                                                                |
+| `jenkins_token`          | string                                     | ✅        |                    | Jenkins main token                                                                          |
+| `jenkins_client_id`      | string                                     | ✅        |                    | Jenkins main Client ID used with IAP                                                        |
+| `jenkins_sa_credentials` | string                                     | ✅        |                    | Jenkins service account credentials to use with IAP                                         |
+| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                                 |
+| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                          |
 | `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only         |
 | `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                                       |
 | `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                                     |
@@ -27,7 +27,7 @@ The list of arguments, that are used in GH Action:
 | `use-prebuilt-image`     | string                                     |          | false              | If a prebuilt Storybook Docker image should be used                                         |
 | `jenkins-folder-name`    | string                                     |          |                    | Jenkins folder where the deployment jobs are located                                        |
 | `generate-types-command` | string                                     |          | false              | Command to generate gql types                                                               |
-| `pr-number`              | string                                     |          |                    | Event number of the original pr, in case event number or issue number is not present. .     |
+| `pr-number`              | string                                     |          | false              | Event number of the original pr, in case event number or issue number is not present        |
 | `checkout-token`         | string                                     |          |                    | Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners           |
 | `node-version`           | string                                     |          | 18                 | Node.js version used. The action is guaranteed to work only with Node.js@18 (default value) |
 
@@ -40,20 +40,17 @@ Not specified
 All ENV Variables, defined in a GH Workflow are also passed to a GH Action. It means, the might be reused as is.
 This is a list of ENV Variables that are used in GH Action:
 
-| name                           | description                                                                           |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
-| `GITHUB_TOKEN`                 | GitHub token. Is used to checkout `davinci` branch                                    |
-| `GCR_ACCOUNT_KEY`              | Necessary token to push image to Google cloud                                         |
-| `GCR_GQL_SCHEMAS_BUCKET_TOKEN` | Necessary token to pull GQL schema from Google Cloud                                  |
-| `NPM_TOKEN`                    | Necessary token to install private dependencies                                       |
+| name                           | description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `GITHUB_TOKEN`                 | GitHub token. Is used to checkout `davinci` branch   |
+| `GCR_ACCOUNT_KEY`              | Necessary token to push image to Google cloud        |
+| `GCR_GQL_SCHEMAS_BUCKET_TOKEN` | Necessary token to pull GQL schema from Google Cloud |
+| `NPM_TOKEN`                    | Necessary token to install private dependencies      |
 
 ### Usage
 
 ```yaml
   - uses: toptal/davinci-github-actions/deploy-storybook@v4.4.2
-    env:
-      GITHUB_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
-      GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
     with:
       jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_URL }}
       jenkins_build_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}

--- a/deploy-storybook/README.md
+++ b/deploy-storybook/README.md
@@ -12,8 +12,13 @@ The list of arguments, that are used in GH Action:
 
 | name                     | type                                       | required | default            | description                                                                                 |
 | ------------------------ | ------------------------------------------ | -------- | ------------------ | ------------------------------------------------------------------------------------------- |
-| `sha`                    | string                                     | ✅        |                    | Commit hash that will be used as a tag for the Docker image                                 |
-| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅        |                    | Environment to deploy Storybook to                                                          |
+| `jenkins_url`            | string                                     | ✅       |                    | Jenkins instance URL                                                                        |
+| `jenkins_user`           | string                                     | ✅       |                    | Jenkins user                                                                                |
+| `jenkins_token`          | string                                     | ✅       |                    | Jenkins token                                                                               |
+| `jenkins_client_id`      | string                                     | ✅       |                    | Jenkins Client ID used with IAP                                                             |
+| `jenkins_sa_credentials` | string                                     | ✅       |                    | Jenkins service account credentials to use with IAP                                         |
+| `sha`                    | string                                     | ✅       |                    | Commit hash that will be used as a tag for the Docker image                                 |
+| `environment`            | enum<<br/>`temploy`,<br/>`staging`,<br/>>' | ✅       |                    | Environment to deploy Storybook to                                                          |
 | `env-file`               | string                                     |          | .env.temploy       | `.env` file name from which to read variables. Required for temploy deployment only         |
 | `davinci-branch`         | string                                     |          | master             | Custom davinci branch                                                                       |
 | `dist-folder`            | string                                     |          | ./storybook-static | Path to folder where Storybook is built                                                     |
@@ -40,7 +45,6 @@ This is a list of ENV Variables that are used in GH Action:
 | `GITHUB_TOKEN`                 | GitHub token. Is used to checkout `davinci` branch                                    |
 | `GCR_ACCOUNT_KEY`              | Necessary token to push image to Google cloud                                         |
 | `GCR_GQL_SCHEMAS_BUCKET_TOKEN` | Necessary token to pull GQL schema from Google Cloud                                  |
-| `JENKINS_DEPLOY_TOKEN`         | Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ |
 | `NPM_TOKEN`                    | Necessary token to install private dependencies                                       |
 
 ### Usage
@@ -50,8 +54,15 @@ This is a list of ENV Variables that are used in GH Action:
     env:
       GITHUB_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
       GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
-      JENKINS_DEPLOY_TOKEN: ${{ secrets.TOPTAL_JENKINS_BUILD_TOKEN }}
     with:
+      jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_URL }}
+      jenkins_build_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
+      jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
+      jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_TOKEN }}
+      jenkins_build_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+      jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_CLIENT_ID }}
+      jenkins_build_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
+      jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
       sha: f41daf47ca1a72cc3f6eb50118eccfb2deadb613
       environment: temploy
 ```

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -62,7 +62,7 @@ inputs:
     required: false
     default: 'false'
   pr-number:
-    description: Event number of the original pr, in case event number or issue number is not present. .
+    description: Event number of the original pr, in case event number or issue number is not present
     required: false
     default: 'false'
   checkout-token:
@@ -76,63 +76,63 @@ inputs:
 runs:
   using: composite
   steps:
-    # - name: Set up node
-    #   uses: actions/setup-node@v3
-    #   with:
-    #     node-version: ${{ inputs.node-version }}
+    - name: Set up node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
 
-    # - name: Install Dependencies
-    #   if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-    #   uses: toptal/davinci-github-actions/yarn-install@v6.0.0
-    #   with:
-    #     checkout-token: ${{ inputs.checkout-token }}
+    - name: Install Dependencies
+      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
+      uses: toptal/davinci-github-actions/yarn-install@v6.0.0
+      with:
+        checkout-token: ${{ inputs.checkout-token }}
 
-    # - name: Generate Types
-    #   if: ${{ inputs.generate-types-command != 'false' }}
-    #   uses: toptal/davinci-github-actions/generate-gql-types@v6.0.0
-    #   with:
-    #     generate-types-command: ${{ inputs.generate-types-command }}
-    #     gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
+    - name: Generate Types
+      if: ${{ inputs.generate-types-command != 'false' }}
+      uses: toptal/davinci-github-actions/generate-gql-types@v6.0.0
+      with:
+        generate-types-command: ${{ inputs.generate-types-command }}
+        gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
 
-    # - name: Build Storybook
-    #   if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-    #   shell: bash
-    #   env:
-    #     BUILD_COMMAND: ${{ inputs.build-command }}
-    #   run: yarn "$BUILD_COMMAND"
+    - name: Build Storybook
+      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
+      shell: bash
+      env:
+        BUILD_COMMAND: ${{ inputs.build-command }}
+      run: yarn "$BUILD_COMMAND"
 
-    # - name: Specify Repository, Jenkins folder and Release Name
-    #   id: repo
-    #   shell: bash
-    #   env:
-    #     FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
-    #     EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
-    #   run: |
-    #     folder_name=$FOLDER_NAME
+    - name: Specify Repository, Jenkins folder and Release Name
+      id: repo
+      shell: bash
+      env:
+        FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
+        EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
+      run: |
+        folder_name=$FOLDER_NAME
 
-    #     if [[ "$folder_name" == '' ]]; then
-    #       echo folder_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
-    #     else
-    #       echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
-    #     fi
+        if [[ "$folder_name" == '' ]]; then
+          echo folder_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
+        else
+          echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
+        fi
 
-    #     echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-    #     echo "release_name=${{ github.event.repository.name }}-pr-$EVENT_NUMBER-storybook" >> $GITHUB_OUTPUT
-    #     echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
+        echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+        echo "release_name=${{ github.event.repository.name }}-pr-$EVENT_NUMBER-storybook" >> $GITHUB_OUTPUT
+        echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
 
-    # - name: Build and Push Storybook Image
-    #   uses: toptal/davinci-github-actions/build-push-image@v6.0.0
-    #   if: ${{ inputs.use-prebuilt-image == 'false' }}
-    #   with:
-    #     sha: ${{ inputs.sha }}
-    #     image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
-    #     build-args: |
-    #       DIST_FOLDER=${{ inputs.dist-folder }}
-    #       NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
-    #       ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
-    #       VERSION=${{ inputs.sha }}
-    #     docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
-    #     davinci-branch: ${{ inputs.davinci-branch }}
+    - name: Build and Push Storybook Image
+      uses: toptal/davinci-github-actions/build-push-image@v6.0.0
+      if: ${{ inputs.use-prebuilt-image == 'false' }}
+      with:
+        sha: ${{ inputs.sha }}
+        image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
+        build-args: |
+          DIST_FOLDER=${{ inputs.dist-folder }}
+          NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
+          ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
+          VERSION=${{ inputs.sha }}
+        docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
+        davinci-branch: ${{ inputs.davinci-branch }}
 
     - name: Trigger Deploy to Staging
       if: ${{ inputs.environment == 'staging' }}
@@ -142,24 +142,23 @@ runs:
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
       with:
         jenkins_url: ${{ inputs.jenkins_url }}
-        jenkins_user: ${{ inputs.jenkins_user }} ##toptal-devbot
-        jenkins_token: ${{ inputs.jenkins_token }} ##${{ env.JENKINS_DEPLOY_TOKEN }}
+        jenkins_user: ${{ inputs.jenkins_user }}
+        jenkins_token: ${{ inputs.jenkins_token }}
         jenkins_client_id: ${{ inputs.jenkins_client_id }}
         jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
-        # job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
-        # job_params: |
-        #   {
-        #     "TAG": "${{ inputs.sha }}"
-        #   }
-        job_name: job-test-iap
+        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
+        job_params: |
+          {
+            "TAG": "${{ inputs.sha }}"
+          }
         job_timeout: 1200
 
-    # - uses: toptal/davinci-github-actions/extract-env-variables@v6.0.0
-    #   if: ${{ inputs.environment == 'temploy' }}
-    #   id: env-variables
-    #   with:
-    #     github-token: ${{ env.GITHUB_TOKEN }}
-    #     filename: ${{ inputs.env-file }}
+    - uses: toptal/davinci-github-actions/extract-env-variables@v6.0.0
+      if: ${{ inputs.environment == 'temploy' }}
+      id: env-variables
+      with:
+        github-token: ${{ env.GITHUB_TOKEN }}
+        filename: ${{ inputs.env-file }}
 
     - name: Trigger Deploy to Temploy
       if: ${{ inputs.environment == 'temploy' }}
@@ -170,33 +169,32 @@ runs:
         RELEASE: ${{ steps.repo.outputs.release_name }}
       with:
         jenkins_url: ${{ inputs.jenkins_url }}
-        jenkins_user: ${{ inputs.jenkins_user }} ##toptal-jenkins
-        jenkins_token: ${{ inputs.jenkins_token }} ###${{ env.JENKINS_DEPLOY_TOKEN }}
+        jenkins_user: ${{ inputs.jenkins_user }}
+        jenkins_token: ${{ inputs.jenkins_token }}
         jenkins_client_id: ${{ inputs.jenkins_client_id }}
         jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
-        # job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
-        # job_params: |
-        #   {
-        #     "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
-        #     "RELEASE": "${{ env.RELEASE }}",
-        #     "TAG": "${{ inputs.sha }}",
-        #     "ENV": "${{ steps.env-variables.outputs.variables || 'ENV=null' }}"
-        #   }
-        job_name: job-test-iap
+        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
+        job_params: |
+          {
+            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
+            "RELEASE": "${{ env.RELEASE }}",
+            "TAG": "${{ inputs.sha }}",
+            "ENV": "${{ steps.env-variables.outputs.variables || 'ENV=null' }}"
+          }
         job_timeout: 1200
 
-    # - name: Post Temploy Link
-    #   if: ${{ inputs.environment == 'temploy' }}
-    #   uses: actions/github-script@v6.3.3
-    #   env:
-    #     RELEASE: ${{ steps.repo.outputs.release_name }}
-    #     PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
-    #   with:
-    #     github-token: ${{ env.GITHUB_TOKEN }}
-    #     script: |
-    #       const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
-    #       const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-    #       const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45))
-    #       const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-    #       const number = issue_number || ${{ env.PR_NUMBER }}
-    #       github.rest.issues.createComment({ issue_number: number, owner, repo, body })
+    - name: Post Temploy Link
+      if: ${{ inputs.environment == 'temploy' }}
+      uses: actions/github-script@v6.3.3
+      env:
+        RELEASE: ${{ steps.repo.outputs.release_name }}
+        PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
+      with:
+        github-token: ${{ env.GITHUB_TOKEN }}
+        script: |
+          const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
+          const { issue: { number: issue_number }, repo: { owner, repo }  } = context
+          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45))
+          const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
+          const number = issue_number || ${{ env.PR_NUMBER }}
+          github.rest.issues.createComment({ issue_number: number, owner, repo, body })

--- a/deploy-storybook/action.yml
+++ b/deploy-storybook/action.yml
@@ -6,10 +6,24 @@ description: |
     GITHUB_TOKEN: GitHub token. Is used to checkout `davinci` branch
     GCR_ACCOUNT_KEY: Necessary token to push image to Google cloud
     GCR_GQL_SCHEMAS_BUCKET_TOKEN: Necessary token to pull GQL schema from Google Cloud
-    JENKINS_DEPLOY_TOKEN: Jenkins deployment token. Keep in mind that tokens for `temploy` and `staging` differ
-    NPM_TOKEN:  Necessary token to install private dependencies 
+    NPM_TOKEN:  Necessary token to install private dependencies
 
 inputs:
+  jenkins_url:
+    description: 'Jenkins main instance URL'
+    required: true
+  jenkins_user:
+    description: 'Jenkins user'
+    required: true
+  jenkins_token:
+    description: 'Jenkins main token'
+    required: true
+  jenkins_client_id:
+    description: 'Jenkins main Client ID used with IAP'
+    required: true
+  jenkins_sa_credentials:
+    description: 'Jenkins service account credentials to use with IAP'
+    required: true
   sha:
     description: Commit hash that will be used as a tag for the Docker image
     required: true
@@ -50,133 +64,139 @@ inputs:
   pr-number:
     description: Event number of the original pr, in case event number or issue number is not present. .
     required: false
-    default: false
+    default: 'false'
   checkout-token:
     description: Repository checkout access token `GITHUB_TOKEN`. Required for self hosted runners
     required: false
   node-version:
     required: false
-    default: 18
+    default: '18'
     description: 'Node.js version used. The action is guaranteed to work only with Node.js@18 (default value)'
 
 runs:
   using: composite
   steps:
-    - name: Set up node
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ inputs.node-version }}
+    # - name: Set up node
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: ${{ inputs.node-version }}
 
-    - name: Install Dependencies
-      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-      uses: toptal/davinci-github-actions/yarn-install@v6.0.0
-      with:
-        checkout-token: ${{ inputs.checkout-token }}
+    # - name: Install Dependencies
+    #   if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
+    #   uses: toptal/davinci-github-actions/yarn-install@v6.0.0
+    #   with:
+    #     checkout-token: ${{ inputs.checkout-token }}
 
-    - name: Generate Types
-      if: ${{ inputs.generate-types-command != 'false' }}
-      uses: toptal/davinci-github-actions/generate-gql-types@v6.0.0
-      with:
-        generate-types-command: ${{ inputs.generate-types-command }}
-        gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
+    # - name: Generate Types
+    #   if: ${{ inputs.generate-types-command != 'false' }}
+    #   uses: toptal/davinci-github-actions/generate-gql-types@v6.0.0
+    #   with:
+    #     generate-types-command: ${{ inputs.generate-types-command }}
+    #     gcr-gql-schemas-bucket-token: ${{ env.GCR_GQL_SCHEMAS_BUCKET_TOKEN }}
 
-    - name: Build Storybook
-      if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
-      shell: bash
-      env:
-        BUILD_COMMAND: ${{ inputs.build-command }}
-      run: yarn "$BUILD_COMMAND"
+    # - name: Build Storybook
+    #   if: ${{ inputs.use-prebuilt-package == 'false' && inputs.use-prebuilt-image == 'false' }}
+    #   shell: bash
+    #   env:
+    #     BUILD_COMMAND: ${{ inputs.build-command }}
+    #   run: yarn "$BUILD_COMMAND"
 
-    - name: Specify Repository, Jenkins folder and Release Name
-      id: repo
-      shell: bash
-      env:
-        FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
-        EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
-      run: |
-        folder_name=$FOLDER_NAME
+    # - name: Specify Repository, Jenkins folder and Release Name
+    #   id: repo
+    #   shell: bash
+    #   env:
+    #     FOLDER_NAME: ${{ inputs.jenkins-folder-name }}
+    #     EVENT_NUMBER: ${{ github.event.number || github.event.issue.number || inputs.pr-number }}
+    #   run: |
+    #     folder_name=$FOLDER_NAME
 
-        if [[ "$folder_name" == '' ]]; then
-          echo folder_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
-        else
-          echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
-        fi
+    #     if [[ "$folder_name" == '' ]]; then
+    #       echo folder_name=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
+    #     else
+    #       echo folder_name=$FOLDER_NAME >> $GITHUB_OUTPUT
+    #     fi
 
-        echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-        echo "release_name=${{ github.event.repository.name }}-pr-$EVENT_NUMBER-storybook" >> $GITHUB_OUTPUT
-        echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
-        
-    - name: Build and Push Storybook Image
-      uses: toptal/davinci-github-actions/build-push-image@v6.0.0
-      if: ${{ inputs.use-prebuilt-image == 'false' }}
-      with:
-        sha: ${{ inputs.sha }}
-        image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
-        build-args: |
-          DIST_FOLDER=${{ inputs.dist-folder }}
-          NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
-          ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
-          VERSION=${{ inputs.sha }}
-        docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
-        davinci-branch: ${{ inputs.davinci-branch }}
+    #     echo "repository_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+    #     echo "release_name=${{ github.event.repository.name }}-pr-$EVENT_NUMBER-storybook" >> $GITHUB_OUTPUT
+    #     echo "pr_number=${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
+
+    # - name: Build and Push Storybook Image
+    #   uses: toptal/davinci-github-actions/build-push-image@v6.0.0
+    #   if: ${{ inputs.use-prebuilt-image == 'false' }}
+    #   with:
+    #     sha: ${{ inputs.sha }}
+    #     image-name: ${{ steps.repo.outputs.repository_name }}-storybook-release
+    #     build-args: |
+    #       DIST_FOLDER=${{ inputs.dist-folder }}
+    #       NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
+    #       ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
+    #       VERSION=${{ inputs.sha }}
+    #     docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
+    #     davinci-branch: ${{ inputs.davinci-branch }}
 
     - name: Trigger Deploy to Staging
       if: ${{ inputs.environment == 'staging' }}
-      uses: toptal/jenkins-job-trigger-action@1.0.1
+      uses: toptal/actions/trigger-jenkins-job@main
       env:
         JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
       with:
-        jenkins_url: https://jenkins.toptal.net
-        jenkins_user: toptal-devbot
-        jenkins_token: ${{ env.JENKINS_DEPLOY_TOKEN }}
-        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
-        job_params: |
-          {
-            "TAG": "${{ inputs.sha }}"
-          }
+        jenkins_url: ${{ inputs.jenkins_url }}
+        jenkins_user: ${{ inputs.jenkins_user }} ##toptal-devbot
+        jenkins_token: ${{ inputs.jenkins_token }} ##${{ env.JENKINS_DEPLOY_TOKEN }}
+        jenkins_client_id: ${{ inputs.jenkins_client_id }}
+        jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
+        # job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-staging-deployment
+        # job_params: |
+        #   {
+        #     "TAG": "${{ inputs.sha }}"
+        #   }
+        job_name: job-test-iap
         job_timeout: 1200
 
-    - uses: toptal/davinci-github-actions/extract-env-variables@v6.0.0
-      if: ${{ inputs.environment == 'temploy' }}
-      id: env-variables
-      with:
-        github-token: ${{ env.GITHUB_TOKEN }}
-        filename: ${{ inputs.env-file }}
+    # - uses: toptal/davinci-github-actions/extract-env-variables@v6.0.0
+    #   if: ${{ inputs.environment == 'temploy' }}
+    #   id: env-variables
+    #   with:
+    #     github-token: ${{ env.GITHUB_TOKEN }}
+    #     filename: ${{ inputs.env-file }}
 
     - name: Trigger Deploy to Temploy
       if: ${{ inputs.environment == 'temploy' }}
-      uses: toptal/jenkins-job-trigger-action@1.0.1
+      uses: toptal/actions/trigger-jenkins-job@main
       env:
         JENKINS_FOLDER_NAME: ${{ steps.repo.outputs.folder_name }}
         REPOSITORY_NAME: ${{ steps.repo.outputs.repository_name }}
         RELEASE: ${{ steps.repo.outputs.release_name }}
       with:
-        jenkins_url: https://jenkins-build.toptal.net/
-        jenkins_user: toptal-jenkins
-        jenkins_token: ${{ env.JENKINS_DEPLOY_TOKEN }}
-        job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
-        job_params: |
-          {
-            "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
-            "RELEASE": "${{ env.RELEASE }}",
-            "TAG": "${{ inputs.sha }}",
-            "ENV": "${{ steps.env-variables.outputs.variables || 'ENV=null' }}"
-          }
+        jenkins_url: ${{ inputs.jenkins_url }}
+        jenkins_user: ${{ inputs.jenkins_user }} ##toptal-jenkins
+        jenkins_token: ${{ inputs.jenkins_token }} ###${{ env.JENKINS_DEPLOY_TOKEN }}
+        jenkins_client_id: ${{ inputs.jenkins_client_id }}
+        jenkins_sa_credentials: ${{ inputs.jenkins_sa_credentials }}
+        # job_name: ${{ env.JENKINS_FOLDER_NAME }}/job/${{ env.REPOSITORY_NAME }}-storybook-temploy-helm-run
+        # job_params: |
+        #   {
+        #     "REPOSITORY_NAME": "${{ env.REPOSITORY_NAME }}-storybook",
+        #     "RELEASE": "${{ env.RELEASE }}",
+        #     "TAG": "${{ inputs.sha }}",
+        #     "ENV": "${{ steps.env-variables.outputs.variables || 'ENV=null' }}"
+        #   }
+        job_name: job-test-iap
         job_timeout: 1200
 
-    - name: Post Temploy Link
-      if: ${{ inputs.environment == 'temploy' }}
-      uses: actions/github-script@v6.3.3
-      env:
-        RELEASE: ${{ steps.repo.outputs.release_name }}
-        PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
-      with:
-        github-token: ${{ env.GITHUB_TOKEN }}
-        script: |
-          const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
-          const { issue: { number: issue_number }, repo: { owner, repo }  } = context
-          const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45))
-          const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
-          const number = issue_number || ${{ env.PR_NUMBER }}
-          github.rest.issues.createComment({ issue_number: number, owner, repo, body })
+    # - name: Post Temploy Link
+    #   if: ${{ inputs.environment == 'temploy' }}
+    #   uses: actions/github-script@v6.3.3
+    #   env:
+    #     RELEASE: ${{ steps.repo.outputs.release_name }}
+    #     PR_NUMBER: ${{ steps.repo.outputs.pr_number }}
+    #   with:
+    #     github-token: ${{ env.GITHUB_TOKEN }}
+    #     script: |
+    #       const trimSuffix = (name) => name.endsWith('-') ? name.slice(0, -1) : name
+    #       const { issue: { number: issue_number }, repo: { owner, repo }  } = context
+    #       const name = trimSuffix(['${{ env.RELEASE }}', '${{ steps.repo.outputs.repository_name }}-storybook'].join('-').substring(0, 45))
+    #       const body = `Storybook temploy is available at https://${name}.toptal.rocks :tada:`
+    #       const number = issue_number || ${{ env.PR_NUMBER }}
+    #       github.rest.issues.createComment({ issue_number: number, owner, repo, body })


### PR DESCRIPTION
[CI-3043]

### Description
The CI team is currently working on replacing the external-proxy with Google Identity Aware Proxy (IAP). More info [here](https://cloud.google.com/iap/docs/concepts-overview).

IAP is a Google service that allows control access to web applications running on GCP. It provides a security layer for applications by ensuring that only authenticated and authorized users/service accounts can access them. To programmatically access a resource protected by the IAP, we need to generate a JWT token and pass it alongside the request to authenticate before accessing the protected resource.

Currently, we use the jenkins-job-trigger-action to trigger Jenkins jobs from a GH workflow. Since this is a public action repo and to not expose our internal infrastructure implementation, we created the new private action ([trigger-jenkins-job](https://github.com/toptal/actions/tree/main/trigger-jenkins-job)) to implement the IAP necessary steps for authentication and authorization. This new action requires two new inputs (secrets) used in the action’s steps to generate the authentication token: jenkins_client_id and jenkins_sa_credentials.

The IAP is already enabled for our Jenkins servers in alternative URLs during the migration, that’s why we use the secret JENKINS_URL. Its main role is to make it easier and transparent when we turn the key to enable IAP in the production’s Jenkins URLs.

In this PR, we switch to the new trigger-jenkins-job action that implements the underlying steps to authenticate with IAP when triggering a jenkins job from a GitHub workflow.

### Review
- [x] Get 👍 from code review
- [x] Removed labels that block merging (wip, do-not-merge, needs-management-approval)

[CI-3043]: https://toptal-core.atlassian.net/browse/CI-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ