### PR TITLE
[FX-NULL] Rename max attempts parameter in yarn-install

### DIFF
--- a/.changeset/nine-actors-camp.md
+++ b/.changeset/nine-actors-camp.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- standardise max attempts parameter in `yarn-install`

--- a/.changeset/nine-actors-camp.md
+++ b/.changeset/nine-actors-camp.md
@@ -2,4 +2,4 @@
 'davinci-github-actions': patch
 ---
 
-- standardise max attempts parameter in `yarn-install`
+- rename max attempts parameter in `yarn-install`

--- a/yarn-install/README.md
+++ b/yarn-install/README.md
@@ -17,7 +17,7 @@ The list of arguments, that are used in GH Action:
 | `path`           | string |          | .       | Relative path under $GITHUB\_WORKSPACE where to run `yarn install` command                                                                                                                                                                  |
 | `checkout-token` | string |          |         | Repository checkout access token `GITHUB_TOKEN`. Required for self-hosted runners                                                                                                                                                           |
 | `npm-gar-token`  | string |          |         | Repository npm Artifact Registry access token `NPM_GAR_TOKEN`. Required when using self-hosted runners with npm in GAR (Google Artifact Registry, the npm registry works as a proxy-cache, downloading and storing the public npm packages) |
-| `maxAttempts`    | string |          | 1       | How many times to retry installing. This is specially useful if the building of packages might fail because of network connections                                                                                                          |
+| `max-attempts`   | string |          | 1       | How many times to retry installing. This is specially useful if the building of packages might fail because of network connections                                                                                                          |
 
 ### Outputs
 

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -18,7 +18,7 @@ inputs:
   npm-gar-token:
     description: Repository npm Artifact Registry access token `NPM_GAR_TOKEN`. Required when using self-hosted runners with npm in GAR (Google Artifact Registry, the npm registry works as a proxy-cache, downloading and storing the public npm packages)
     required: false
-  maxAttempts:
+  max-attempts:
     description: How many times to retry installing. This is specially useful if the building of packages might fail because of network connections
     default: "1"
     required: false


### PR DESCRIPTION
No Jira ticket.

### Description

The following warning was discovered after updating to latest version of davinci-github-actions in Staff Portal (https://github.com/toptal/staff-portal/actions/runs/7420502487/job/20192208624#step:9:1)

<img width="1097" alt="Screenshot 2024-01-05 at 12 40 03" src="https://github.com/toptal/davinci-github-actions/assets/1390758/5514cd54-48ca-44ea-8d8e-31cd69694105">

This pull request renames the parameter and makes it aligned with format of other parameters

### How to test

- Parameter name change

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
