### PR TITLE
Add updated dependency package

### DIFF
--- a/update-dependency-to-latest/README.md
+++ b/update-dependency-to-latest/README.md
@@ -1,0 +1,32 @@
+## Update dependency to latest
+
+Create a PR for updating a dependency to the latest version
+
+### Description
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name               | type   | required | default | description                                                                                     |
+| ------------------ | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `dependency-regex` | string | ✅        |         | Regex pattern for NPM package names that should be updated, leave it blank to update everything |
+| `pr-title`         | string |          |         | Title for the PR created                                                                        |
+
+### Outputs
+
+Not specified
+
+### ENV Variables
+
+Not specified
+
+### Usage
+
+```yaml
+  # Updating picasso and davinci packages
+  - uses: toptal/davinci-github-actions/update-dependency-to-latest
+    with:
+      dependency-regex: "@toptal/(picasso|davinci)"
+      pr-title: Bump Picasso and Davinci
+```

--- a/update-dependency-to-latest/action.yml
+++ b/update-dependency-to-latest/action.yml
@@ -1,0 +1,57 @@
+name: Update dependency to latest
+description: Create a PR for updating a dependency to the latest version
+
+inputs:
+  dependency-regex:
+    required: true
+    description: Regex pattern for NPM package names that should be updated, leave it blank to update everything
+  pr-title:
+    description: Title for the PR created
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      name: Bump dependencies to the latest version
+      id: bump-versions
+      run: |
+        filter="${{ inputs.dependency-regex }}"
+
+        syncpack() {
+          npx --yes syncpack@11 "$@"
+        }
+
+        old_versions=$(syncpack list --filter "$filter")
+        printf "old-versions=%s\n" "$old_versions" > "$GITHUB_OUTPUT"
+
+        echo | syncpack update --filter "$filter"
+
+        new_versions=$(syncpack list --filter "$filter")
+        printf "new-versions=%s\n" "$new_versions" > "$GITHUB_OUTPUT"
+
+    - name: Install packages
+      uses: toptal/davinci-github-actions/yarn-install
+
+    - name: Commit changes to new branch and create PR
+      shell: bash
+      run: |
+        git config --global user.email "bot@toptal.com"
+        git config --global user.name "toptal-devbot"
+
+        formatted_pr_name=$(gh pr view "${{ github.event.inputs.pull_request_url }}" --json headRefName | jq -r ".headRefName")
+        git checkout -b "$formatted_pr_name"
+
+        old_versions=$(sort <<< "${{ steps.bump-versions.outputs.old-versions }}")
+        new_versions=$(sort <<< "${{ steps.bump-versions.outputs.new-versions }}")
+
+        changed_versions=$(comm -13 <(cat <<< "$old_versions") <(cat <<< "$new_versions"))
+
+        git add .
+        git commit --no-verify -m "${{ inputs.pr-title }}"
+        git push --no-verify -u origin "$formatted_pr_name"
+
+        gh pr create --draft \
+          --title "${{ inputs.pr-title }}" \
+          --body "Updating packages to the latest versions available. It was created automatically from ${{ github.event.inputs.pull_request_url }}.\n\nVersions changed:\n\n$changed_versions" \
+          --base "master" \
+          --head "$formatted_pr_name"


### PR DESCRIPTION
[FX-4724]

### Description

Add action for updating a NPM dependency to the latest version possible. Useful for Picasso and Davinci updates

### How to test

- WIP

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
