### PR TITLE
Add safe guard for title before sending to github api

### DIFF
--- a/.changeset/small-icons-behave.md
+++ b/.changeset/small-icons-behave.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- add safeguard to not send empty title to github api

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -26,9 +26,6 @@ runs:
 
           const updatedTitle = convertConventional(context.payload.pull_request.title)
 
-          console.log('title', context.payload.pull_request.title)
-          console.log('updatedTitle', updatedTitle)
-
           const newPr = {
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -24,13 +24,20 @@ runs:
             return capitalize(titleMessage.trim()) ?? title
           }
 
+          const updatedTitle = convertConventional(context.payload.pull_request.title)
+
+          console.log('title', context.payload.pull_request.title)
+          console.log('updatedTitle', updatedTitle)
+
           const newPr = {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
-            title: convertConventional(context.payload.pull_request.title)
+            title: updatedTitle,
           }
 
-          github.rest.pulls.update(newPr);
+          if (title) {
+            github.rest.pulls.update(newPr);
+          }
 
 

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -36,7 +36,7 @@ runs:
             title: updatedTitle,
           }
 
-          if (title) {
+          if (updatedTitle) {
             github.rest.pulls.update(newPr);
           }
 

--- a/pr-conventional-to-toptal-commits/action.yml
+++ b/pr-conventional-to-toptal-commits/action.yml
@@ -21,10 +21,11 @@ runs:
             const pattern = /^\w+(?:\(.+\))?: (.*)$/
             const [, titleMessage = ''] = title.match(pattern) ?? []
 
-            return capitalize(titleMessage.trim()) ?? title
+            return capitalize(titleMessage.trim()) || title
           }
 
-          const updatedTitle = convertConventional(context.payload.pull_request.title)
+          const oldTitle = context.payload.pull_request.title
+          const updatedTitle = convertConventional(oldTitle)
 
           const newPr = {
             owner: context.repo.owner,
@@ -33,7 +34,7 @@ runs:
             title: updatedTitle,
           }
 
-          if (updatedTitle) {
+          if (oldTitle !== updatedTitle) {
             github.rest.pulls.update(newPr);
           }
 


### PR DESCRIPTION
[FX-4757]

### Description

It seems that dependabot started creating PRs with proper title format - [example](https://github.com/toptal/staff-portal/pull/11734) (check history). And when that happens the regexp is empty so the title is always empty string.

Some PRs are still opened with the old format - [example](https://github.com/toptal/topkit/pull/448)

### How to test

- tested in topkit https://github.com/toptal/topkit/actions/runs/7570724233/job/20616702367?pr=448

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4757]: https://toptal-core.atlassian.net/browse/FX-4757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ