### PR TITLE
Bump node version to 20 for two actions

### DIFF
--- a/.changeset/real-clocks-provide.md
+++ b/.changeset/real-clocks-provide.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### Node version bumps
+
+- upgrade Node to V20 for create-matrix and get-changeset-info actions

--- a/create-matrix/action.yml
+++ b/create-matrix/action.yml
@@ -19,5 +19,5 @@ outputs:
     description: Information about current repository || boolean
 
 runs:
-  using: node18
+  using: node20
   main: dist/index.js

--- a/get-changeset-info/action.yml
+++ b/get-changeset-info/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: Packages that have changed but are missing in changesets || Array<string>
 
 runs:
-  using: node18
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
[FX-4769]

### Description

Bump node version for `create-matrix` and `get-changeset-info` actions.

### How to test

- Use  `toptal/davinci-github-actions/create-matrix@bump-node-version-create-matrix-action` in i.e. Talent Activation repo: https://github.com/toptal/talent-activation-frontend/actions/runs/7624098507/job/20765549609?pr=2005. This failed previously due to version mismatch: https://github.com/toptal/talent-activation-frontend/actions/runs/7623751639/job/20764417446

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4769]: https://toptal-core.atlassian.net/browse/FX-4769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ