### PR TITLE
[FX-4795] Add feature to notify a fallback group

### DIFF
--- a/.changeset/cold-ducks-argue.md
+++ b/.changeset/cold-ducks-argue.md
@@ -6,4 +6,4 @@
 
 ### Notify about build failure
 
-- add opportunity to notify a fallback group in slack
+- add feature to notify a fallback group in slack

--- a/.changeset/cold-ducks-argue.md
+++ b/.changeset/cold-ducks-argue.md
@@ -2,8 +2,4 @@
 'davinci-github-actions': minor
 ---
 
----
-
-### Notify about build failure
-
 - add feature to notify a fallback group in slack

--- a/.changeset/cold-ducks-argue.md
+++ b/.changeset/cold-ducks-argue.md
@@ -2,4 +2,8 @@
 'davinci-github-actions': minor
 ---
 
+---
+
+### Notify about build failure
+
 - add opportunity to notify a fallback group in slack

--- a/.changeset/cold-ducks-argue.md
+++ b/.changeset/cold-ducks-argue.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add opportunity to notify a fallback group in slack

--- a/notify-about-build-failure/README.md
+++ b/notify-about-build-failure/README.md
@@ -17,7 +17,7 @@ The list of arguments, that are used in GH Action:
 | `slack-channel-name`        | string | ✅        |         | Slack channel name (for example, `#-test-channel`)                                                                                         |
 | `github-commit-author-name` | string | ✅        |         | GitHub name of commit author, needed for finding the Slack handle of commit author                                                         |
 | `github-action-run-url`     | string | ✅        |         | Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message |
-| `fallback-slack-team-name`  | string |          |         | Fallback Slack team name, needed for the notification message if the commit author is not found                                            |
+| `fallback-slack-team-id`    | string |          |         | Fallback Slack team ID, needed for the notification message if the commit author is not found                                              |
 
 ### Outputs
 

--- a/notify-about-build-failure/README.md
+++ b/notify-about-build-failure/README.md
@@ -17,7 +17,7 @@ The list of arguments, that are used in GH Action:
 | `slack-channel-name`        | string | ✅        |         | Slack channel name (for example, `#-test-channel`)                                                                                         |
 | `github-commit-author-name` | string | ✅        |         | GitHub name of commit author, needed for finding the Slack handle of commit author                                                         |
 | `github-action-run-url`     | string | ✅        |         | Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message |
-| `fallback-slack-team-id`    | string |          |         | Fallback Slack team ID, needed for the notification message if the commit author is not found                                              |
+| `fallback-slack-team-id`    | string |          |         | team ID to use when commit author is not found                                                                                             |
 
 ### Outputs
 

--- a/notify-about-build-failure/README.md
+++ b/notify-about-build-failure/README.md
@@ -17,6 +17,7 @@ The list of arguments, that are used in GH Action:
 | `slack-channel-name`        | string | ✅        |         | Slack channel name (for example, `#-test-channel`)                                                                                         |
 | `github-commit-author-name` | string | ✅        |         | GitHub name of commit author, needed for finding the Slack handle of commit author                                                         |
 | `github-action-run-url`     | string | ✅        |         | Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message |
+| `fallback-slack-team-name`  | string |          |         | Fallback Slack team name, needed for the notification message if the commit author is not found                                            |
 
 ### Outputs
 

--- a/notify-about-build-failure/action.yml
+++ b/notify-about-build-failure/action.yml
@@ -16,8 +16,8 @@ inputs:
   github-action-run-url:
     description: Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message
     required: true
-  fallback-slack-team-name:
-    description: Fallback Slack team name, needed for the notification message if the commit author is not found
+  fallback-slack-team-id:
+    description: Fallback Slack team ID, needed for the notification message if the commit author is not found
     required: false
   
 runs:

--- a/notify-about-build-failure/action.yml
+++ b/notify-about-build-failure/action.yml
@@ -16,6 +16,9 @@ inputs:
   github-action-run-url:
     description: Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message
     required: true
+  fallback-slack-team-name:
+    description: Fallback Slack team name, needed for the notification message if the commit author is not found
+    required: false
   
 runs:
   using: node20

--- a/notify-about-build-failure/action.yml
+++ b/notify-about-build-failure/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: Failing GitHub Acton run URL (for example, `https://github.com/toptal/staff-portal/actions/runs/123`), needed for the notification message
     required: true
   fallback-slack-team-id:
-    description: Fallback Slack team ID, needed for the notification message if the commit author is not found
+    description: team ID to use when commit author is not found
     required: false
   
 runs:

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2820,9 +2820,9 @@ var __webpack_exports__ = {};
 const core = __nccwpck_require__(186)
 const https = __nccwpck_require__(687)
 
-// const slackBotToken = core.getInput('slack-bot-token')
+const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
-// const slackChannelName = core.getInput('slack-channel-name')
+const slackChannelName = core.getInput('slack-channel-name')
 const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
 const githubActionRunUrl = core.getInput('github-action-run-url')
@@ -2839,15 +2839,15 @@ const TOP_TEAM_API_OPTIONS = {
 }
 
 // Configuration for Slack API access
-// const SLACK_API_OPTIONS = {
-//   hostname: 'slack.com',
-//   path: '/api/chat.postMessage',
-//   method: 'POST',
-//   headers: {
-//     'Content-Type': 'application/json',
-//     Authorization: `Bearer ${slackBotToken}`,
-//   },
-// }
+const SLACK_API_OPTIONS = {
+  hostname: 'slack.com',
+  path: '/api/chat.postMessage',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${slackBotToken}`,
+  },
+}
 
 const getSlackMessage = (
   slackHandle,
@@ -2855,25 +2855,25 @@ const getSlackMessage = (
 ) => `Hello <@${slackHandle}>!
 Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
-// const sendSlackMessage = body => {
-//   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
-//     slackResponse.on('data', slackResult => {
-//       const result = JSON.parse(slackResult)
+const sendSlackMessage = body => {
+  const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
+    slackResponse.on('data', slackResult => {
+      const result = JSON.parse(slackResult)
 
-//       if (!result.ok) {
-//         console.error(result)
-//       }
-//     })
-//   })
+      if (!result.ok) {
+        console.error(result)
+      }
+    })
+  })
 
-//   slackRequest.write(JSON.stringify(body))
+  slackRequest.write(JSON.stringify(body))
 
-//   slackRequest.on('error', error => {
-//     console.error(error)
-//   })
+  slackRequest.on('error', error => {
+    console.error(error)
+  })
 
-//   slackRequest.end()
-// }
+  slackRequest.end()
+}
 
 const communicationChannelsBody = JSON.stringify({
   query: `
@@ -2928,8 +2928,6 @@ const getCommunicationChannelsRequest = https.request(
               channel.value === githubCommitAuthorName
           )
         })
-      
-      console.log('member: ', member)
 
       if (member) {
         const slack = member.communicationChannels.find(
@@ -2937,29 +2935,22 @@ const getCommunicationChannelsRequest = https.request(
         )
 
         slackIdentifier = slack.value
-        const message = getSlackMessage(slack.value, githubActionRunUrl)
+        const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'
         )
 
-        console.log('message: ', message)
-        console.log('privateMessageChannelId: ', privateMessageChannelId)
-
-        // sendSlackMessage({
-        //   text: message,
-        //   channel: privateMessageChannelId,
-        // })
+        sendSlackMessage({
+          text: message,
+          channel: privateMessageChannelId,
+        })
       }
 
       if (slackIdentifier) {
-        console.log(
-          'message: ',
-          getSlackMessage(slackIdentifier, githubActionRunUrl)
-        )
-        // sendSlackMessage({
-        //   text: getSlackMessage(slackIdentifier, githubActionRunUrl),
-        //   channel: slackChannelName,
-        // })
+        sendSlackMessage({
+          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          channel: slackChannelName,
+        })
       } else {
         throw new Error('No slack identifier found')
       }

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2922,8 +2922,14 @@ const getCommunicationChannelsRequest = https.request(
       const member = teams
         .flatMap(team => team.directRoles.map(role => role.member))
         .find(member => {
-          return member.communicationChannels.some(channel => channel.kind === 'GITHUB' && channel.value === githubCommitAuthorName)
-        });
+          return member.communicationChannels.some(
+            channel =>
+              channel.kind === 'GITHUB' &&
+              channel.value === githubCommitAuthorName
+          )
+        })
+      
+      console.log('member: ', member)
 
       if (member) {
         const slack = member.communicationChannels.find(
@@ -2932,7 +2938,9 @@ const getCommunicationChannelsRequest = https.request(
 
         slackIdentifier = slack.value
         const message = getSlackMessage(slack.value, githubActionRunUrl)
-        const privateMessageChannelId = new URLSearchParams(slack.link).get('id')
+        const privateMessageChannelId = new URLSearchParams(slack.link).get(
+          'id'
+        )
 
         console.log('message: ', message)
         console.log('privateMessageChannelId: ', privateMessageChannelId)
@@ -2944,7 +2952,10 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       if (slackIdentifier) {
-        console.log('message: ', getSlackMessage(slackIdentifier, githubActionRunUrl))
+        console.log(
+          'message: ',
+          getSlackMessage(slackIdentifier, githubActionRunUrl)
+        )
         // sendSlackMessage({
         //   text: getSlackMessage(slackIdentifier, githubActionRunUrl),
         //   channel: slackChannelName,

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2823,8 +2823,9 @@ const https = __nccwpck_require__(687)
 // const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
 // const slackChannelName = core.getInput('slack-channel-name')
+const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
-// const githubActionRunUrl = core.getInput('github-action-run-url')
+const githubActionRunUrl = core.getInput('github-action-run-url')
 
 // Configuration for TopTeam API access
 const TOP_TEAM_API_OPTIONS = {
@@ -2848,11 +2849,11 @@ const TOP_TEAM_API_OPTIONS = {
 //   },
 // }
 
-// const getSlackMessage = (
-//   slackHandle,
-//   githubActionRunUrl
-// ) => `Hello <@${slackHandle}>!
-// Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
+const getSlackMessage = (
+  slackHandle,
+  githubActionRunUrl
+) => `Hello <@${slackHandle}>!
+Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
 // const sendSlackMessage = body => {
 //   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
@@ -2898,7 +2899,6 @@ const communicationChannelsBody = JSON.stringify({
 const getCommunicationChannelsRequest = https.request(
   TOP_TEAM_API_OPTIONS,
   res => {
-    let isNotified = false
     let result = ''
 
     res.setEncoding('utf8')
@@ -2917,50 +2917,40 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      console.log('teams: ', teams)
-      teams.some(team => {
-        team.directRoles.some(({ member }) => {
-          const github = member.communicationChannels.find(
-            channel =>
-              channel.kind === 'GITHUB' &&
-              channel.value === githubCommitAuthorName
-          )
+      let slackIdentifier = fallbackSlackTeamName
 
-          if (github) {
-            const slack = member.communicationChannels.find(
-              channel => channel.kind === 'SLACK'
-            )
+      const member = teams
+        .flatMap(team => team.directRoles.map(role => role.member))
+        .find(member => {
+          return member.communicationChannels.some(channel => channel.kind === 'GITHUB' && channel.value === githubCommitAuthorName)
+        });
 
-            // const message = getSlackMessage(slack.value, githubActionRunUrl)
+      if (member) {
+        const slack = member.communicationChannels.find(
+          channel => channel.kind === 'SLACK'
+        )
 
-            // const privateMessageChannelId = new URLSearchParams(slack.link).get(
-            //   'id'
-            // )
+        slackIdentifier = slack.value
+        const message = getSlackMessage(slack.value, githubActionRunUrl)
+        const privateMessageChannelId = new URLSearchParams(slack.link).get('id')
 
-            console.log('slack: ', slack)
+        console.log('message: ', message)
+        console.log('privateMessageChannelId: ', privateMessageChannelId)
 
-            // sendSlackMessage({
-            //   text: message,
-            //   channel: privateMessageChannelId,
-            // })
+        // sendSlackMessage({
+        //   text: message,
+        //   channel: privateMessageChannelId,
+        // })
+      }
 
-            // sendSlackMessage({
-            //   text: message,
-            //   channel: slackChannelName,
-            // })
-
-            isNotified = true
-          }
-
-          return isNotified
-        })
-
-        return isNotified
-      })
-
-      if (!isNotified) {
-        const errorMessage = `Unable to notify commit author ${githubCommitAuthorName}`
-        throw new Error(errorMessage)
+      if (slackIdentifier) {
+        console.log('message: ', getSlackMessage(slackIdentifier, githubActionRunUrl))
+        // sendSlackMessage({
+        //   text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+        //   channel: slackChannelName,
+        // })
+      } else {
+        throw new Error('No slack identifier found')
       }
     })
   }

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2917,9 +2917,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      let slackIdentifier = `!subteam^${fallbackSlackTeamId}`
-
-      const member = teams
+      const teamMember = teams
         .flatMap(team => team.directRoles.map(role => role.member))
         .find(member => {
           return member.communicationChannels.some(
@@ -2929,13 +2927,12 @@ const getCommunicationChannelsRequest = https.request(
           )
         })
 
-      if (member) {
-        const slack = member.communicationChannels.find(
+      if (teamMember) {
+        const slack = teamMember.communicationChannels.find(
           channel => channel.kind === 'SLACK'
         )
 
-        slackIdentifier = `@${slack.value}`
-        const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
+        const message = getSlackMessage(`@${slack.value}`, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'
         )
@@ -2946,12 +2943,12 @@ const getCommunicationChannelsRequest = https.request(
         })
 
         sendSlackMessage({
-          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          text: message,
           channel: slackChannelName,
         })
       } else if (fallbackSlackTeamId) {
         sendSlackMessage({
-          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          text: getSlackMessage(`!subteam^${fallbackSlackTeamId}`, githubActionRunUrl),
           channel: slackChannelName,
         })
       } else {

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2944,9 +2944,12 @@ const getCommunicationChannelsRequest = https.request(
           text: message,
           channel: privateMessageChannelId,
         })
-      }
 
-      if (slackIdentifier) {
+        sendSlackMessage({
+          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          channel: slackChannelName,
+        })
+      } else if (fallbackSlackTeamId) {
         sendSlackMessage({
           text: getSlackMessage(slackIdentifier, githubActionRunUrl),
           channel: slackChannelName,

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2823,7 +2823,7 @@ const https = __nccwpck_require__(687)
 const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
 const slackChannelName = core.getInput('slack-channel-name')
-const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
+const fallbackSlackTeamId = core.getInput('fallback-slack-team-id')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
 const githubActionRunUrl = core.getInput('github-action-run-url')
 
@@ -2852,7 +2852,7 @@ const SLACK_API_OPTIONS = {
 const getSlackMessage = (
   slackHandle,
   githubActionRunUrl
-) => `Hello <@${slackHandle}>!
+) => `Hello <${slackHandle}>!
 Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
 const sendSlackMessage = body => {
@@ -2917,7 +2917,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      let slackIdentifier = fallbackSlackTeamName
+      let slackIdentifier = `!subteam^${fallbackSlackTeamId}`
 
       const member = teams
         .flatMap(team => team.directRoles.map(role => role.member))
@@ -2934,7 +2934,7 @@ const getCommunicationChannelsRequest = https.request(
           channel => channel.kind === 'SLACK'
         )
 
-        slackIdentifier = slack.value
+        slackIdentifier = `@${slack.value}`
         const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'

--- a/notify-about-build-failure/dist/index.js
+++ b/notify-about-build-failure/dist/index.js
@@ -2820,11 +2820,11 @@ var __webpack_exports__ = {};
 const core = __nccwpck_require__(186)
 const https = __nccwpck_require__(687)
 
-const slackBotToken = core.getInput('slack-bot-token')
+// const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
-const slackChannelName = core.getInput('slack-channel-name')
+// const slackChannelName = core.getInput('slack-channel-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
-const githubActionRunUrl = core.getInput('github-action-run-url')
+// const githubActionRunUrl = core.getInput('github-action-run-url')
 
 // Configuration for TopTeam API access
 const TOP_TEAM_API_OPTIONS = {
@@ -2838,41 +2838,41 @@ const TOP_TEAM_API_OPTIONS = {
 }
 
 // Configuration for Slack API access
-const SLACK_API_OPTIONS = {
-  hostname: 'slack.com',
-  path: '/api/chat.postMessage',
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${slackBotToken}`,
-  },
-}
+// const SLACK_API_OPTIONS = {
+//   hostname: 'slack.com',
+//   path: '/api/chat.postMessage',
+//   method: 'POST',
+//   headers: {
+//     'Content-Type': 'application/json',
+//     Authorization: `Bearer ${slackBotToken}`,
+//   },
+// }
 
-const getSlackMessage = (
-  slackHandle,
-  githubActionRunUrl
-) => `Hello <@${slackHandle}>!
-Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
+// const getSlackMessage = (
+//   slackHandle,
+//   githubActionRunUrl
+// ) => `Hello <@${slackHandle}>!
+// Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
-const sendSlackMessage = body => {
-  const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
-    slackResponse.on('data', slackResult => {
-      const result = JSON.parse(slackResult)
+// const sendSlackMessage = body => {
+//   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
+//     slackResponse.on('data', slackResult => {
+//       const result = JSON.parse(slackResult)
 
-      if (!result.ok) {
-        console.error(result)
-      }
-    })
-  })
+//       if (!result.ok) {
+//         console.error(result)
+//       }
+//     })
+//   })
 
-  slackRequest.write(JSON.stringify(body))
+//   slackRequest.write(JSON.stringify(body))
 
-  slackRequest.on('error', error => {
-    console.error(error)
-  })
+//   slackRequest.on('error', error => {
+//     console.error(error)
+//   })
 
-  slackRequest.end()
-}
+//   slackRequest.end()
+// }
 
 const communicationChannelsBody = JSON.stringify({
   query: `
@@ -2917,7 +2917,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-
+      console.log('teams: ', teams)
       teams.some(team => {
         team.directRoles.some(({ member }) => {
           const github = member.communicationChannels.find(
@@ -2931,20 +2931,23 @@ const getCommunicationChannelsRequest = https.request(
               channel => channel.kind === 'SLACK'
             )
 
-            const message = getSlackMessage(slack.value, githubActionRunUrl)
+            // const message = getSlackMessage(slack.value, githubActionRunUrl)
 
-            const privateMessageChannelId = new URLSearchParams(slack.link).get(
-              'id'
-            )
-            sendSlackMessage({
-              text: message,
-              channel: privateMessageChannelId,
-            })
+            // const privateMessageChannelId = new URLSearchParams(slack.link).get(
+            //   'id'
+            // )
 
-            sendSlackMessage({
-              text: message,
-              channel: slackChannelName,
-            })
+            console.log('slack: ', slack)
+
+            // sendSlackMessage({
+            //   text: message,
+            //   channel: privateMessageChannelId,
+            // })
+
+            // sendSlackMessage({
+            //   text: message,
+            //   channel: slackChannelName,
+            // })
 
             isNotified = true
           }

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -4,7 +4,7 @@ const https = require('https')
 const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
 const slackChannelName = core.getInput('slack-channel-name')
-const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
+const fallbackSlackTeamId = core.getInput('fallback-slack-team-id')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
 const githubActionRunUrl = core.getInput('github-action-run-url')
 
@@ -33,7 +33,7 @@ const SLACK_API_OPTIONS = {
 const getSlackMessage = (
   slackHandle,
   githubActionRunUrl
-) => `Hello <@${slackHandle}>!
+) => `Hello <${slackHandle}>!
 Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
 const sendSlackMessage = body => {
@@ -98,7 +98,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      let slackIdentifier = fallbackSlackTeamName
+      let slackIdentifier = `!subteam^${fallbackSlackTeamId}`
 
       const member = teams
         .flatMap(team => team.directRoles.map(role => role.member))
@@ -115,7 +115,7 @@ const getCommunicationChannelsRequest = https.request(
           channel => channel.kind === 'SLACK'
         )
 
-        slackIdentifier = slack.value
+        slackIdentifier = `@${slack.value}`
         const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -98,9 +98,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      let slackIdentifier = `!subteam^${fallbackSlackTeamId}`
-
-      const member = teams
+      const teamMember = teams
         .flatMap(team => team.directRoles.map(role => role.member))
         .find(member => {
           return member.communicationChannels.some(
@@ -110,13 +108,12 @@ const getCommunicationChannelsRequest = https.request(
           )
         })
 
-      if (member) {
-        const slack = member.communicationChannels.find(
+      if (teamMember) {
+        const slack = teamMember.communicationChannels.find(
           channel => channel.kind === 'SLACK'
         )
 
-        slackIdentifier = `@${slack.value}`
-        const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
+        const message = getSlackMessage(`@${slack.value}`, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'
         )
@@ -127,12 +124,15 @@ const getCommunicationChannelsRequest = https.request(
         })
 
         sendSlackMessage({
-          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          text: message,
           channel: slackChannelName,
         })
       } else if (fallbackSlackTeamId) {
         sendSlackMessage({
-          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          text: getSlackMessage(
+            `!subteam^${fallbackSlackTeamId}`,
+            githubActionRunUrl
+          ),
           channel: slackChannelName,
         })
       } else {

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -125,9 +125,12 @@ const getCommunicationChannelsRequest = https.request(
           text: message,
           channel: privateMessageChannelId,
         })
-      }
 
-      if (slackIdentifier) {
+        sendSlackMessage({
+          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          channel: slackChannelName,
+        })
+      } else if (fallbackSlackTeamId) {
         sendSlackMessage({
           text: getSlackMessage(slackIdentifier, githubActionRunUrl),
           channel: slackChannelName,

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -110,6 +110,8 @@ const getCommunicationChannelsRequest = https.request(
           )
         })
 
+      console.log('member: ', member)
+
       if (member) {
         const slack = member.communicationChannels.find(
           channel => channel.kind === 'SLACK'

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -4,8 +4,9 @@ const https = require('https')
 // const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
 // const slackChannelName = core.getInput('slack-channel-name')
+const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
-// const githubActionRunUrl = core.getInput('github-action-run-url')
+const githubActionRunUrl = core.getInput('github-action-run-url')
 
 // Configuration for TopTeam API access
 const TOP_TEAM_API_OPTIONS = {
@@ -29,11 +30,11 @@ const TOP_TEAM_API_OPTIONS = {
 //   },
 // }
 
-// const getSlackMessage = (
-//   slackHandle,
-//   githubActionRunUrl
-// ) => `Hello <@${slackHandle}>!
-// Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
+const getSlackMessage = (
+  slackHandle,
+  githubActionRunUrl
+) => `Hello <@${slackHandle}>!
+Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
 // const sendSlackMessage = body => {
 //   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
@@ -79,7 +80,6 @@ const communicationChannelsBody = JSON.stringify({
 const getCommunicationChannelsRequest = https.request(
   TOP_TEAM_API_OPTIONS,
   res => {
-    let isNotified = false
     let result = ''
 
     res.setEncoding('utf8')
@@ -98,50 +98,49 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-      console.log('teams: ', teams)
-      teams.some(team => {
-        team.directRoles.some(({ member }) => {
-          const github = member.communicationChannels.find(
+      let slackIdentifier = fallbackSlackTeamName
+
+      const member = teams
+        .flatMap(team => team.directRoles.map(role => role.member))
+        .find(member => {
+          return member.communicationChannels.some(
             channel =>
               channel.kind === 'GITHUB' &&
               channel.value === githubCommitAuthorName
           )
-
-          if (github) {
-            const slack = member.communicationChannels.find(
-              channel => channel.kind === 'SLACK'
-            )
-
-            // const message = getSlackMessage(slack.value, githubActionRunUrl)
-
-            // const privateMessageChannelId = new URLSearchParams(slack.link).get(
-            //   'id'
-            // )
-
-            console.log('slack: ', slack)
-
-            // sendSlackMessage({
-            //   text: message,
-            //   channel: privateMessageChannelId,
-            // })
-
-            // sendSlackMessage({
-            //   text: message,
-            //   channel: slackChannelName,
-            // })
-
-            isNotified = true
-          }
-
-          return isNotified
         })
 
-        return isNotified
-      })
+      if (member) {
+        const slack = member.communicationChannels.find(
+          channel => channel.kind === 'SLACK'
+        )
 
-      if (!isNotified) {
-        const errorMessage = `Unable to notify commit author ${githubCommitAuthorName}`
-        throw new Error(errorMessage)
+        slackIdentifier = slack.value
+        const message = getSlackMessage(slack.value, githubActionRunUrl)
+        const privateMessageChannelId = new URLSearchParams(slack.link).get(
+          'id'
+        )
+
+        console.log('message: ', message)
+        console.log('privateMessageChannelId: ', privateMessageChannelId)
+
+        // sendSlackMessage({
+        //   text: message,
+        //   channel: privateMessageChannelId,
+        // })
+      }
+
+      if (slackIdentifier) {
+        console.log(
+          'message: ',
+          getSlackMessage(slackIdentifier, githubActionRunUrl)
+        )
+        // sendSlackMessage({
+        //   text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+        //   channel: slackChannelName,
+        // })
+      } else {
+        throw new Error('No slack identifier found')
       }
     })
   }

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -1,9 +1,9 @@
 const core = require('@actions/core')
 const https = require('https')
 
-// const slackBotToken = core.getInput('slack-bot-token')
+const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
-// const slackChannelName = core.getInput('slack-channel-name')
+const slackChannelName = core.getInput('slack-channel-name')
 const fallbackSlackTeamName = core.getInput('fallback-slack-team-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
 const githubActionRunUrl = core.getInput('github-action-run-url')
@@ -20,15 +20,15 @@ const TOP_TEAM_API_OPTIONS = {
 }
 
 // Configuration for Slack API access
-// const SLACK_API_OPTIONS = {
-//   hostname: 'slack.com',
-//   path: '/api/chat.postMessage',
-//   method: 'POST',
-//   headers: {
-//     'Content-Type': 'application/json',
-//     Authorization: `Bearer ${slackBotToken}`,
-//   },
-// }
+const SLACK_API_OPTIONS = {
+  hostname: 'slack.com',
+  path: '/api/chat.postMessage',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${slackBotToken}`,
+  },
+}
 
 const getSlackMessage = (
   slackHandle,
@@ -36,25 +36,25 @@ const getSlackMessage = (
 ) => `Hello <@${slackHandle}>!
 Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
-// const sendSlackMessage = body => {
-//   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
-//     slackResponse.on('data', slackResult => {
-//       const result = JSON.parse(slackResult)
+const sendSlackMessage = body => {
+  const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
+    slackResponse.on('data', slackResult => {
+      const result = JSON.parse(slackResult)
 
-//       if (!result.ok) {
-//         console.error(result)
-//       }
-//     })
-//   })
+      if (!result.ok) {
+        console.error(result)
+      }
+    })
+  })
 
-//   slackRequest.write(JSON.stringify(body))
+  slackRequest.write(JSON.stringify(body))
 
-//   slackRequest.on('error', error => {
-//     console.error(error)
-//   })
+  slackRequest.on('error', error => {
+    console.error(error)
+  })
 
-//   slackRequest.end()
-// }
+  slackRequest.end()
+}
 
 const communicationChannelsBody = JSON.stringify({
   query: `
@@ -110,37 +110,28 @@ const getCommunicationChannelsRequest = https.request(
           )
         })
 
-      console.log('member: ', member)
-
       if (member) {
         const slack = member.communicationChannels.find(
           channel => channel.kind === 'SLACK'
         )
 
         slackIdentifier = slack.value
-        const message = getSlackMessage(slack.value, githubActionRunUrl)
+        const message = getSlackMessage(slackIdentifier, githubActionRunUrl)
         const privateMessageChannelId = new URLSearchParams(slack.link).get(
           'id'
         )
 
-        console.log('message: ', message)
-        console.log('privateMessageChannelId: ', privateMessageChannelId)
-
-        // sendSlackMessage({
-        //   text: message,
-        //   channel: privateMessageChannelId,
-        // })
+        sendSlackMessage({
+          text: message,
+          channel: privateMessageChannelId,
+        })
       }
 
       if (slackIdentifier) {
-        console.log(
-          'message: ',
-          getSlackMessage(slackIdentifier, githubActionRunUrl)
-        )
-        // sendSlackMessage({
-        //   text: getSlackMessage(slackIdentifier, githubActionRunUrl),
-        //   channel: slackChannelName,
-        // })
+        sendSlackMessage({
+          text: getSlackMessage(slackIdentifier, githubActionRunUrl),
+          channel: slackChannelName,
+        })
       } else {
         throw new Error('No slack identifier found')
       }

--- a/notify-about-build-failure/index.js
+++ b/notify-about-build-failure/index.js
@@ -1,11 +1,11 @@
 const core = require('@actions/core')
 const https = require('https')
 
-const slackBotToken = core.getInput('slack-bot-token')
+// const slackBotToken = core.getInput('slack-bot-token')
 const topTeamApiKey = core.getInput('top-team-api-key')
-const slackChannelName = core.getInput('slack-channel-name')
+// const slackChannelName = core.getInput('slack-channel-name')
 const githubCommitAuthorName = core.getInput('github-commit-author-name')
-const githubActionRunUrl = core.getInput('github-action-run-url')
+// const githubActionRunUrl = core.getInput('github-action-run-url')
 
 // Configuration for TopTeam API access
 const TOP_TEAM_API_OPTIONS = {
@@ -19,41 +19,41 @@ const TOP_TEAM_API_OPTIONS = {
 }
 
 // Configuration for Slack API access
-const SLACK_API_OPTIONS = {
-  hostname: 'slack.com',
-  path: '/api/chat.postMessage',
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${slackBotToken}`,
-  },
-}
+// const SLACK_API_OPTIONS = {
+//   hostname: 'slack.com',
+//   path: '/api/chat.postMessage',
+//   method: 'POST',
+//   headers: {
+//     'Content-Type': 'application/json',
+//     Authorization: `Bearer ${slackBotToken}`,
+//   },
+// }
 
-const getSlackMessage = (
-  slackHandle,
-  githubActionRunUrl
-) => `Hello <@${slackHandle}>!
-Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
+// const getSlackMessage = (
+//   slackHandle,
+//   githubActionRunUrl
+// ) => `Hello <@${slackHandle}>!
+// Build ${githubActionRunUrl} is currently failing on master, please fix it to unblock the release candidate or let the proper team know.`
 
-const sendSlackMessage = body => {
-  const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
-    slackResponse.on('data', slackResult => {
-      const result = JSON.parse(slackResult)
+// const sendSlackMessage = body => {
+//   const slackRequest = https.request(SLACK_API_OPTIONS, slackResponse => {
+//     slackResponse.on('data', slackResult => {
+//       const result = JSON.parse(slackResult)
 
-      if (!result.ok) {
-        console.error(result)
-      }
-    })
-  })
+//       if (!result.ok) {
+//         console.error(result)
+//       }
+//     })
+//   })
 
-  slackRequest.write(JSON.stringify(body))
+//   slackRequest.write(JSON.stringify(body))
 
-  slackRequest.on('error', error => {
-    console.error(error)
-  })
+//   slackRequest.on('error', error => {
+//     console.error(error)
+//   })
 
-  slackRequest.end()
-}
+//   slackRequest.end()
+// }
 
 const communicationChannelsBody = JSON.stringify({
   query: `
@@ -98,7 +98,7 @@ const getCommunicationChannelsRequest = https.request(
       }
 
       const teams = parsedResult.data.orgUnits.nodes
-
+      console.log('teams: ', teams)
       teams.some(team => {
         team.directRoles.some(({ member }) => {
           const github = member.communicationChannels.find(
@@ -112,20 +112,23 @@ const getCommunicationChannelsRequest = https.request(
               channel => channel.kind === 'SLACK'
             )
 
-            const message = getSlackMessage(slack.value, githubActionRunUrl)
+            // const message = getSlackMessage(slack.value, githubActionRunUrl)
 
-            const privateMessageChannelId = new URLSearchParams(slack.link).get(
-              'id'
-            )
-            sendSlackMessage({
-              text: message,
-              channel: privateMessageChannelId,
-            })
+            // const privateMessageChannelId = new URLSearchParams(slack.link).get(
+            //   'id'
+            // )
 
-            sendSlackMessage({
-              text: message,
-              channel: slackChannelName,
-            })
+            console.log('slack: ', slack)
+
+            // sendSlackMessage({
+            //   text: message,
+            //   channel: privateMessageChannelId,
+            // })
+
+            // sendSlackMessage({
+            //   text: message,
+            //   channel: slackChannelName,
+            // })
 
             isNotified = true
           }


### PR DESCRIPTION
[FX-4795]

### Description

#### Notify about build failure

We added a new feature to notify a fallback Slack group by default

### How to test

- Run `toptal/davinci-github-actions/notify-about-build-failure@fx-4795-extend-notifier` with `fallback-slack-team-id` input

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4795]: https://toptal-core.atlassian.net/browse/FX-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ