### PR TITLE
[FX-4787] Create tickets for major dependabot updates

### DIFF
--- a/.changeset/yellow-jokes-cheer.md
+++ b/.changeset/yellow-jokes-cheer.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- enable notify-jira-about-contribution action to create tickets for major dependabot pull requests

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,13 +10,15 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name           | type   | required | default | description                           |
-| -------------- | ------ | -------- | ------- | ------------------------------------- |
-| `team`         | string | ✅        |         | Team that we are checking against     |
-| `repo`         | string | ✅        |         | Repository name                       |
-| `pull-number`  | string | ✅        |         | Nth pull request                      |
-| `jira-hook`    | string | ✅        |         | JIRA automation hook for contribution |
-| `github-token` | string | ✅        |         | Token for authorization               |
+| name                                    | type   | required | default              | description                           |
+| --------------------------------------- | ------ | -------- | -------------------- | ------------------------------------- |
+| `team`                                  | string | ✅        |                      | Team that we are checking against     |
+| `repo`                                  | string | ✅        |                      | Repository name                       |
+| `pull-number`                           | string | ✅        |                      | Nth pull request                      |
+| `jira-hook`                             | string | ✅        |                      | JIRA automation hook for contribution |
+| `github-token`                          | string | ✅        |                      | Token for authorization               |
+| `notify-about-major-dependabot-updates` | string |          |                      | Notify about major dependabot updates |
+| `dependabot-ticket-jira-label`          | string |          | ready-for-refinement | Label for dependabot ticket in JIRA   |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -51,9 +51,7 @@ runs:
 
     - name: Check if PR comes fron dependabot
       env:
-        # TODO: revert before merge
-        # IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'dependabot[bot]' }}
-        IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'sashuk' }}
+        IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'dependabot[bot]' }}
       id: is-dependabot
       shell: bash
       run: |
@@ -70,11 +68,7 @@ runs:
       env:
         IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
         IS_DEPENDABOT: ${{ steps.is-dependabot.outputs.result }}
-
-        # TODO: revert before merge
-        # IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
-        IS_DRAFT: false
-
+        IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
         NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.notify-about-major-dependabot-updates }}
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
@@ -82,7 +76,7 @@ runs:
       run: |
         echo "Checking if Jira ticket already exists or PR is a draft"
         if [[ ${{ env.JIRA_ISSUE_ALREADY_EXISTS }} == "true" || ${{ env.IS_DRAFT }} == "true" ]]; then
-          echo "result=true" >> $GITHUB_OUTPUT
+          echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
@@ -120,14 +114,6 @@ runs:
 
         echo "result=false" >> $GITHUB_OUTPUT
 
-    # TODO: remove before merge
-    - name: Debug output
-      shell: bash
-      env:
-        PREVIOUS_STEP_RESULT: ${{ steps.is-pr-eligible.outputs.result }}
-      run: |
-        echo "Previous step result: ${{ env.PREVIOUS_STEP_RESULT }}"
-
     # Create JIRA issue
     - name: Add label - JIRA issue created - for non-Draft PR
       if: ${{ steps.is-pr-eligible.outputs.result == true }}
@@ -141,19 +127,18 @@ runs:
       with:
         add-labels: ${{ inputs.dependabot-ticket-jira-label }}
 
-    # TODO: uncomment to create actual ticket before the merge
-    # - name: Create JIRA ticket
-    #   if: ${{ steps.jira-issue-can-be-created.outputs.result == true }}
-    #   shell: bash
-    #   env:
-    #     JIRA_HOOK: ${{ inputs.jira-hook }}
-    #     REPO: ${{ inputs.repo }}
-    #     TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
-    #     AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
-    #     AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
-    #     NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
-    #     URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
-    #   run: bash ${{ github.action_path }}/notify-jira.sh
+    - name: Create JIRA ticket
+      if: ${{ steps.jira-issue-can-be-created.outputs.result == true }}
+      shell: bash
+      env:
+        JIRA_HOOK: ${{ inputs.jira-hook }}
+        REPO: ${{ inputs.repo }}
+        TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
+        AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
+        AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
+        NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
+        URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
+      run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
       if: ${{ steps.jira-issue-can-be-created.outputs.result == true && steps.is-dependabot.outputs.result == false }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -18,6 +18,15 @@ inputs:
   github-token:
     required: true
     description: Token for authorization
+  notify-about-major-dependabot-updates:
+    required: false
+    description: Notify about major dependabot updates
+    type: boolean
+    default: false
+  dependabot-ticket-jira-label:
+    required: false
+    description: Label for dependabot ticket in JIRA
+    default: "ready-for-refinement"
 
 runs:
   using: composite
@@ -32,48 +41,122 @@ runs:
         pull-number: ${{ inputs.pull-number }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    - uses: toptal/davinci-github-actions/is-team-member@v6.0.0
+    - name: Check if author is a member of specific team
+      uses: toptal/davinci-github-actions/is-team-member@v6.0.0
       id: is-team-member
       with:
         team: ${{ inputs.team }}
         login: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
         github-token: ${{ inputs.github-token }}
 
-    - name: Define if PR is eligible - PR authored by external contributor and is not draft
+    - name: Check if PR comes fron dependabot
       env:
-        IS_NOT_DEPENDABOT_BOT: ${{ fromJson(steps.get-pr.outputs.data).user.login != 'dependabot[bot]' }}
+        # TODO: revert before merge
+        # IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'dependabot[bot]' }}
+        IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'sashuk' }}
+      id: is-dependabot
+      shell: bash
+      run: |
+        echo "result=${{ env.IS_DEPENDABOT }}" >> $GITHUB_OUTPUT
+
+    - name: Check if Jira issue already exists
+      id: jira-issue-already-exists
+      shell: bash
+      run: |
+        echo "result=${{ contains(github.event.pull_request.labels.*.name, 'contribution') }}" >> $GITHUB_OUTPUT
+
+    - name: Decide if Jira ticket needs to be created
       id: is-pr-eligible
+      env:
+        IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
+        IS_DEPENDABOT: ${{ steps.is-dependabot.outputs.result }}
+
+        # TODO: revert before merge
+        # IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
+        IS_DRAFT: false
+
+        NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.notify-about-major-dependabot-updates }}
+        JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
+        PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash
       run: |
-        echo "result=${{ fromJson(steps.is-team-member.outputs.result) == false && fromJson(steps.get-pr.outputs.data).draft == false && env.IS_NOT_DEPENDABOT_BOT }}" >> $GITHUB_OUTPUT
+        echo "Checking if Jira ticket already exists or PR is a draft"
+        if [[ ${{ env.JIRA_ISSUE_ALREADY_EXISTS }} == "true" || ${{ env.IS_DRAFT }} == "true" ]]; then
+          echo "result=true" >> $GITHUB_OUTPUT
+          exit
+        fi
 
-    - name: Jira issue can be created
-      id: jira-issue-can-be-created
+        update_string="${{ env.PR_TITLE }}"
+
+        old_version=$(echo "$update_string" | awk '{match($0, /[0-9]+(\.[0-9]+)*/, arr); print arr[0]}')
+        new_version=$(echo "$update_string" | awk '{match($0, /to [0-9]+(\.[0-9]+)*/, arr); gsub("to ", "", arr[0]); print arr[0]}')
+
+        old_major=$(echo "$old_version" | cut -d. -f1)
+        new_major=$(echo "$new_version" | cut -d. -f1)
+
+        isMajorUpdate=false
+        if [ "$old_major" != "$new_major" ]; then
+          isMajorUpdate=true
+        fi
+
+        isTeamMember=${{ env.IS_TEAM_MEMBER }}
+        isDependabot=${{ env.IS_DEPENDABOT }}
+        notifyAboutMajorDependabotUpdates=${{ env.NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
+        if [[ $notifyAboutMajorDependabotUpdates == "true" && $isDependabot == "true" ]]; then
+          if [[ $isMajorUpdate == "true" ]]; then
+            echo "Major dependabot update"
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "Non-major dependabot update"
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+
+          exit
+        fi
+
+        if [[ $isTeamMember == "false" ]]; then
+          echo "result=true" >> $GITHUB_OUTPUT
+        fi
+
+        echo "result=false" >> $GITHUB_OUTPUT
+
+    # TODO: remove before merge
+    - name: Debug output
       shell: bash
+      env:
+        PREVIOUS_STEP_RESULT: ${{ steps.is-pr-eligible.outputs.result }}
       run: |
-        echo "result=${{ fromJson(steps.is-pr-eligible.outputs.result) == true && !contains(github.event.pull_request.labels.*.name, 'contribution') }}" >> $GITHUB_OUTPUT
+        echo "Previous step result: ${{ env.PREVIOUS_STEP_RESULT }}"
 
+    # Create JIRA issue
     - name: Add label - JIRA issue created - for non-Draft PR
-      if: ${{ fromJson(steps.is-pr-eligible.outputs.result) == true }}
+      if: ${{ steps.is-pr-eligible.outputs.result == true }}
       uses: andymckay/labeler@1.0.4
       with:
         add-labels: "contribution"
 
-    - name: Notify JIRA
-      if: ${{ fromJson(steps.is-pr-eligible.outputs.result) == true && fromJson(steps.jira-issue-can-be-created.outputs.result) == true }}
-      shell: bash
-      env:
-        JIRA_HOOK: ${{ inputs.jira-hook }}
-        REPO: ${{ inputs.repo }}
-        TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
-        AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
-        AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
-        NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
-        URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
-      run: bash ${{ github.action_path }}/notify-jira.sh
+    - name: Add label for dependabot pull requests
+      if: ${{ steps.is-pr-eligible.outputs.result == true && steps.is-dependabot.outputs.result == true }}
+      uses: andymckay/labeler@1.0.4
+      with:
+        add-labels: ${{ inputs.dependabot-ticket-jira-label }}
+
+    # TODO: uncomment to create actual ticket before the merge
+    # - name: Create JIRA ticket
+    #   if: ${{ steps.jira-issue-can-be-created.outputs.result == true }}
+    #   shell: bash
+    #   env:
+    #     JIRA_HOOK: ${{ inputs.jira-hook }}
+    #     REPO: ${{ inputs.repo }}
+    #     TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
+    #     AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
+    #     AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
+    #     NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
+    #     URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
+    #   run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
-      if: ${{ fromJson(steps.is-pr-eligible.outputs.result) == true && fromJson(steps.jira-issue-can-be-created.outputs.result) == true }}
+      if: ${{ steps.jira-issue-can-be-created.outputs.result == true && steps.is-dependabot.outputs.result == false }}
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
[FX-4787]

### Description

This pull request enables `notify-jira-about-contribution` action to create tickets for major `dependabot` updates.

⚠️ Please note that pull request uses some temporary settings to simplify testing, they will be removed before merge

### How to test

- update title of https://github.com/toptal/staff-portal/pull/11998 pull request, rerun the https://github.com/toptal/staff-portal/actions/runs/7789224900/job/21243203956 action, and observe the output of the action

or

- ✅ when pull request title is `Bump some-dependency from 2.30.0 to 3.1.0`, it is detected as major dependency update like in https://github.com/toptal/staff-portal/actions/runs/7789224900/job/21243203956#step:5:329
- ✅ when pull request title is `Bump some-dependency from 4 to 5`, it is detected as major dependency update like in https://github.com/toptal/staff-portal/actions/runs/7789224900/job/21243283607#step:5:329
- 🔴 when pull request title is `Bump some-dependency from 3.12 to 3.1`, it is **not** detected as major dependency like in https://github.com/toptal/staff-portal/actions/runs/7789224900/job/21243334555#step:5:329

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4787]: https://toptal-core.atlassian.net/browse/FX-4787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ