### PR TITLE
[FX-4787] Fix step names

### DIFF
--- a/.changeset/slow-impalas-hang.md
+++ b/.changeset/slow-impalas-hang.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- fix logic and step names in `notify-jira-about-contribution` action

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,15 +10,14 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name                                    | type   | required | default              | description                           |
-| --------------------------------------- | ------ | -------- | -------------------- | ------------------------------------- |
-| `team`                                  | string | ✅        |                      | Team that we are checking against     |
-| `repo`                                  | string | ✅        |                      | Repository name                       |
-| `pull-number`                           | string | ✅        |                      | Nth pull request                      |
-| `jira-hook`                             | string | ✅        |                      | JIRA automation hook for contribution |
-| `github-token`                          | string | ✅        |                      | Token for authorization               |
-| `notify-about-major-dependabot-updates` | string |          |                      | Notify about major dependabot updates |
-| `dependabot-ticket-jira-label`          | string |          | ready-for-refinement | Label for dependabot ticket in JIRA   |
+| name                                    | type   | required | default | description                           |
+| --------------------------------------- | ------ | -------- | ------- | ------------------------------------- |
+| `team`                                  | string | ✅        |         | Team that we are checking against     |
+| `repo`                                  | string | ✅        |         | Repository name                       |
+| `pull-number`                           | string | ✅        |         | Nth pull request                      |
+| `jira-hook`                             | string | ✅        |         | JIRA automation hook for contribution |
+| `github-token`                          | string | ✅        |         | Token for authorization               |
+| `notify-about-major-dependabot-updates` | string |          |         | Notify about major dependabot updates |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -63,8 +63,8 @@ runs:
       run: |
         echo "result=${{ contains(github.event.pull_request.labels.*.name, 'contribution') }}" >> $GITHUB_OUTPUT
 
-    - name: Decide if Jira ticket needs to be created
-      id: is-pr-eligible
+    - name: Decide if Jira ticket should be created
+      id: create-jira-issue
       env:
         IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
         IS_DEPENDABOT: ${{ steps.is-dependabot.outputs.result }}
@@ -116,19 +116,21 @@ runs:
 
     # Create JIRA issue
     - name: Add label - JIRA issue created - for non-Draft PR
-      if: ${{ steps.is-pr-eligible.outputs.result == true }}
+      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true }}
       uses: andymckay/labeler@1.0.4
       with:
+        repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
 
     - name: Add label for dependabot pull requests
-      if: ${{ steps.is-pr-eligible.outputs.result == true && steps.is-dependabot.outputs.result == true }}
+      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot.outputs.result) == true }}
       uses: andymckay/labeler@1.0.4
       with:
+        repo-token: ${{ inputs.github-token }}
         add-labels: ${{ inputs.dependabot-ticket-jira-label }}
 
     - name: Create JIRA ticket
-      if: ${{ steps.jira-issue-can-be-created.outputs.result == true }}
+      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true }}
       shell: bash
       env:
         JIRA_HOOK: ${{ inputs.jira-hook }}
@@ -141,7 +143,7 @@ runs:
       run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
-      if: ${{ steps.jira-issue-can-be-created.outputs.result == true && steps.is-dependabot.outputs.result == false }}
+      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot.outputs.result) == false }}
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: Notify about major dependabot updates
     type: boolean
     default: false
-  dependabot-ticket-jira-label:
-    required: false
-    description: Label for dependabot ticket in JIRA
-    default: "ready-for-refinement"
 
 runs:
   using: composite
@@ -75,7 +71,11 @@ runs:
       shell: bash
       run: |
         echo "Checking if Jira ticket already exists or PR is a draft"
-        if [[ ${{ env.JIRA_ISSUE_ALREADY_EXISTS }} == "true" || ${{ env.IS_DRAFT }} == "true" ]]; then
+        jiraIssueAlreadyExists=${{ env.JIRA_ISSUE_ALREADY_EXISTS }}
+        isDraft=${{ env.IS_DRAFT }}
+        if [[ jiraIssueAlreadyExists == "true" || isDraft == "true" ]]
+        then
+          echo "Jira ticket already exists or PR is a draft, exiting"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
@@ -98,7 +98,7 @@ runs:
         notifyAboutMajorDependabotUpdates=${{ env.NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
         if [[ $notifyAboutMajorDependabotUpdates == "true" && $isDependabot == "true" ]]; then
           if [[ $isMajorUpdate == "true" ]]; then
-            echo "Major dependabot update"
+            echo "Major dependabot update, exiting"
             echo "result=true" >> $GITHUB_OUTPUT
           else
             echo "Non-major dependabot update"
@@ -109,7 +109,9 @@ runs:
         fi
 
         if [[ $isTeamMember == "false" ]]; then
+          echo "Author is not a member of the team, exiting"
           echo "result=true" >> $GITHUB_OUTPUT
+          exit
         fi
 
         echo "result=false" >> $GITHUB_OUTPUT
@@ -121,13 +123,6 @@ runs:
       with:
         repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
-
-    - name: Add label for dependabot pull requests
-      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot.outputs.result) == true }}
-      uses: andymckay/labeler@1.0.4
-      with:
-        repo-token: ${{ inputs.github-token }}
-        add-labels: ${{ inputs.dependabot-ticket-jira-label }}
 
     - name: Create JIRA ticket
       if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true }}


### PR DESCRIPTION
[FX-4787]

### Description

This pull request fixes the step names, so they are properly called. It also removes `dependabot-ticket-jira-label` as it was incorrectly passed to pull request labels (needs to be passed to Jira ticket, follow-up was created https://toptal-core.atlassian.net/browse/FX-4853)

Checked at https://github.com/toptal/staff-portal/pull/12036

### How to test

- The https://github.com/toptal/staff-portal/actions/runs/7830088938/job/21366036170 run created ticket and assigned labels to pull request 

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4787]: https://toptal-core.atlassian.net/browse/FX-4787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ