### PR TITLE
[FX-4878] Fix major version detection

### DIFF
--- a/.changeset/curvy-cows-promise.md
+++ b/.changeset/curvy-cows-promise.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- fix version detection in `notify-jira-about-contribution` action

--- a/.changeset/curvy-cows-promise.md
+++ b/.changeset/curvy-cows-promise.md
@@ -2,4 +2,4 @@
 'davinci-github-actions': patch
 ---
 
-- fix version detection in `notify-jira-about-contribution` action
+- fix major version detection in `notify-jira-about-contribution` action

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,14 +10,14 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name                                    | type   | required | default | description                           |
-| --------------------------------------- | ------ | -------- | ------- | ------------------------------------- |
-| `team`                                  | string | ✅        |         | Team that we are checking against     |
-| `repo`                                  | string | ✅        |         | Repository name                       |
-| `pull-number`                           | string | ✅        |         | Nth pull request                      |
-| `jira-hook`                             | string | ✅        |         | JIRA automation hook for contribution |
-| `github-token`                          | string | ✅        |         | Token for authorization               |
-| `notify-about-major-dependabot-updates` | string |          |         | Notify about major dependabot updates |
+| name                                           | type   | required | default | description                                                                                             |
+| ---------------------------------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `team`                                         | string | ✅        |         | Team that we are checking against                                                                       |
+| `repo`                                         | string | ✅        |         | Repository name                                                                                         |
+| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                        |
+| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                                   |
+| `github-token`                                 | string | ✅        |         | Token for authorization                                                                                 |
+| `should-notify-about-major-dependabot-updates` | string |          |         | Specifies if action should create Jira issues for major dependency update pull requests from dependabot |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,14 +10,14 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name                                           | type   | required | default | description                                                                                             |
-| ---------------------------------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `team`                                         | string | ✅        |         | Team that we are checking against                                                                       |
-| `repo`                                         | string | ✅        |         | Repository name                                                                                         |
-| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                        |
-| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                                   |
-| `github-token`                                 | string | ✅        |         | Token for authorization                                                                                 |
-| `should-notify-about-major-dependabot-updates` | string |          |         | Specifies if action should create Jira issues for major dependency update pull requests from dependabot |
+| name                                           | type   | required | default | description                                                                                         |
+| ---------------------------------------------- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `team`                                         | string | ✅        |         | Team that we are checking against                                                                   |
+| `repo`                                         | string | ✅        |         | Repository name                                                                                     |
+| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                    |
+| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                               |
+| `github-token`                                 | string | ✅        |         | Token for authorization                                                                             |
+| `should-notify-about-major-dependency-updates` | string |          |         | Specifies if action should create Jira issues for major dependency updates (authored by dependabot) |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,14 +10,14 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name                                           | type   | required | default | description                                                                                         |
-| ---------------------------------------------- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------------- |
-| `team`                                         | string | ✅        |         | Team that we are checking against                                                                   |
-| `repo`                                         | string | ✅        |         | Repository name                                                                                     |
-| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                    |
-| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                               |
-| `github-token`                                 | string | ✅        |         | Token for authorization                                                                             |
-| `should-notify-about-major-dependency-updates` | string |          |         | Specifies if action should create Jira issues for major dependency updates (authored by dependabot) |
+| name                                           | type   | required | default | description                                                                                                                               |
+| ---------------------------------------------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `team`                                         | string | ✅        |         | Team that we are checking against                                                                                                         |
+| `repo`                                         | string | ✅        |         | Repository name                                                                                                                           |
+| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                                                          |
+| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                                                                     |
+| `github-token`                                 | string | ✅        |         | Token for authorization                                                                                                                   |
+| `should-notify-about-major-dependency-updates` | string |          |         | Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored) |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -71,14 +71,14 @@ runs:
       shell: bash
       run: |
         jiraIssueAlreadyExists=${{ env.JIRA_ISSUE_ALREADY_EXISTS }}
-        if [[ jiraIssueAlreadyExists == "true" ]]; then
+        if [[ $jiraIssueAlreadyExists == "true" ]]; then
           echo "Jira issue already exists"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
         isDraft=${{ env.IS_DRAFT }}
-        if [[ isDraft == "true" ]]; then
+        if [[ $isDraft == "true" ]]; then
           echo "Pull request is a draft"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
@@ -114,7 +114,6 @@ runs:
         pullRequestTitle="${{ env.PR_TITLE }}"
 
         # Extract major versions using grep utility
-
         # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
         currentMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
         if [ -z "$currentMajorVersion" ]; then

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -119,8 +119,7 @@ runs:
         isDependabot=${{ env.IS_DEPENDABOT }}
         isMajorUpdate=false
         # TODO: REVERT IT TO TRUE
-        if [[ $isDependabot == "false" ]]
-        then
+        if [[ $isDependabot == "false" ]]; then
           echo "It is dependabot PR"
           pr_title="${{ env.PR_TITLE }}"
           extractMajorVersions "$pr_title"
@@ -134,16 +133,22 @@ runs:
 
         isTeamMember=${{ env.IS_TEAM_MEMBER }}
         notifyAboutMajorDependabotUpdates=${{ env.NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
-        if [[ $notifyAboutMajorDependabotUpdates == "true" && $isDependabot == "true" ]]; then
-          if [[ $isMajorUpdate == "true" ]]; then
-            echo "Major dependabot update, exiting"
-            echo "result=true" >> $GITHUB_OUTPUT
-          else
-            echo "Non-major dependabot update"
-            echo "result=false" >> $GITHUB_OUTPUT
-          fi
+        if [[ $isDependabot == "true" ]]; then
+          if [[ $notifyAboutMajorDependabotUpdates == "true" ]]; then
+            if [[ $isMajorUpdate == "true" ]]; then
+              echo "Major dependabot update, exiting"
+              echo "result=true" >> $GITHUB_OUTPUT
+            else
+              echo "Non-major dependabot update"
+              echo "result=false" >> $GITHUB_OUTPUT
+            fi
 
-          exit
+            exit
+          else
+            echo "No notifications for dependabot updates"
+            echo "result=false" >> $GITHUB_OUTPUT
+            exit
+          fi
         fi
 
         if [[ $isTeamMember == "false" ]]; then

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -139,24 +139,24 @@ runs:
               echo "Major dependabot update, exiting"
               echo "result=true" >> $GITHUB_OUTPUT
             else
-              echo "Non-major dependabot update"
+              echo "Non-major dependabot update (create-jira-issue: false), exiting"
               echo "result=false" >> $GITHUB_OUTPUT
             fi
-
-            exit
           else
-            echo "No notifications for dependabot updates"
+            echo "No notifications for dependabot updates (create-jira-issue: false), exiting"
             echo "result=false" >> $GITHUB_OUTPUT
-            exit
           fi
+
+          exit
         fi
 
         if [[ $isTeamMember == "false" ]]; then
-          echo "Author is not a member of the team, exiting"
+          echo "Author is not a member of the team (create-jira-issue: true), exiting"
           echo "result=true" >> $GITHUB_OUTPUT
           exit
         fi
 
+        echo "Exiting (create-jira-issue: false)"
         echo "result=false" >> $GITHUB_OUTPUT
 
     # Create JIRA issue

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -62,11 +62,8 @@ runs:
     - name: Decide if Jira issue should be created
       id: should-create-jira-issue
       env:
-        # TODO: revert before merge
-        #IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
-        IS_TEAM_MEMBER: false
-        #IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
-        IS_DEPENDABOT_PULL_REQUEST: true
+        IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
+        IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
         SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES: ${{ inputs.should-notify-about-major-dependency-updates }}
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -18,9 +18,9 @@ inputs:
   github-token:
     required: true
     description: Token for authorization
-  should-notify-about-major-dependabot-updates:
+  should-notify-about-major-dependency-updates:
     required: false
-    description: Specifies if action should create Jira issues for major dependency update pull requests from dependabot
+    description: Specifies if action should create Jira issues for major dependency updates (authored by dependabot)
     type: boolean
     default: false
 
@@ -65,12 +65,11 @@ runs:
         IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
         IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
-        SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.should-notify-about-major-dependabot-updates }}
+        SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES: ${{ inputs.should-notify-about-major-dependency-updates }}
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash
       run: |
-        # No need to create Jira issue if it already exists
         jiraIssueAlreadyExists=${{ env.JIRA_ISSUE_ALREADY_EXISTS }}
         if [[ jiraIssueAlreadyExists == "true" ]]; then
           echo "Jira issue already exists"
@@ -78,9 +77,8 @@ runs:
           exit
         fi
 
-        # No need to create Jira issue if pull request is a draft
         isDraft=${{ env.IS_DRAFT }}
-        if [[ jiraIssueAlreadyExists == "true" || isDraft == "true" ]]; then
+        if [[ isDraft == "true" ]]; then
           echo "Pull request is a draft"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
@@ -96,48 +94,48 @@ runs:
         if [[ $isDependabotPullRequest == "false" ]]; then
           isTeamMember=${{ env.IS_TEAM_MEMBER }}
           if [[ $isTeamMember == "true" ]]; then
-            echo "Pull request author is member of the team"
+            echo "Pull request author is member of ${{ inputs.team }}"
             echo "result=false" >> $GITHUB_OUTPUT
             exit
           fi
 
-          echo "Pull request author is not a member of the team"
+          echo "Pull request author is not a member of ${{ inputs.team }}"
           echo "result=true" >> $GITHUB_OUTPUT
           exit
         fi
 
-        shouldNotifyAboutMajorDependabotUpdates=${{ env.SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
-        if [[ $shouldNotifyAboutMajorDependabotUpdates == "false" ]]; then
-          echo "No need to notify about dependabot pull requests, exiting"
+        shouldNotifyAboutMajorDependencyUpdates=${{ env.SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES }}
+        if [[ $shouldNotifyAboutMajorDependencyUpdates == "false" ]]; then
+          echo "No need to notify about dependency updates"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
         pullRequestTitle="${{ env.PR_TITLE }}"
 
-        # Extract major version using grep utility
+        # Extract major versions using grep utility
+
         # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
-        oldMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-        if [ -z "$oldMajorVersion" ]; then
-          echo "Error: Unable to extract old major version" >&2
+        currentMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+        if [ -z "$currentMajorVersion" ]; then
+          echo "Error: Unable to extract current major version" >&2
           exit 1
         fi
 
-        # Extract major version using grep utility
-        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "6"
         newMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
         if [ -z "$newMajorVersion" ]; then
           echo "Error: Unable to extract new major version" >&2
           exit 1
         fi
 
-        if [ "$oldMajorVersion" == "$newMajorVersion" ]; then
-          echo "Is not a major dependency update pull request"
+        if [ "$currentMajorVersion" == "$newMajorVersion" ]; then
+          echo "Is not a major dependency update"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
-        echo "Is major dependency update pull request"
+        echo "Is major dependency update"
         echo "result=true" >> $GITHUB_OUTPUT
 
     # Create JIRA issue

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -145,18 +145,19 @@ runs:
         repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
 
-    - name: Create Jira issue
-      if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
-      shell: bash
-      env:
-        JIRA_HOOK: ${{ inputs.jira-hook }}
-        REPO: ${{ inputs.repo }}
-        TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
-        AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
-        AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
-        NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
-        URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
-      run: bash ${{ github.action_path }}/notify-jira.sh
+    # TODO: uncomment it
+    # - name: Create Jira issue
+    #   if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
+    #   shell: bash
+    #   env:
+    #     JIRA_HOOK: ${{ inputs.jira-hook }}
+    #     REPO: ${{ inputs.repo }}
+    #     TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
+    #     AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
+    #     AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
+    #     NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
+    #     URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
+    #   run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
       if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot-pull-request.outputs.result) == false }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: Token for authorization
   should-notify-about-major-dependency-updates:
     required: false
-    description: Specifies if action should create Jira issues for major dependency updates (authored by dependabot)
+    description: Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored)
     type: boolean
     default: false
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -80,20 +80,48 @@ runs:
           exit
         fi
 
+        # Define function to extract major versions from PR title
+        old_major=""
+        new_major=""
+        extractMajorVersions() {
+          echo "Checking if PR is a major update, PR title: $pr_title"
+
+          # Assign function parameter to a variable
+          pr_title=$1
+
+          # Extract number version using grep utility
+          #   - "--only-matching" prints only the matched (non-empty) parts of a matching line
+          #   - "--extended-regexp" allows to use extended regular expressions
+          #   - "cut -d' ' -f2" extracts the second word from the matched line
+          #   - "cut -d'.' -f1" extracts the first part of the version number
+          old_major_value=$(echo "$pr_title" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+
+          # Check if the variable is empty
+          if [ -z "$old_major_value" ]; then
+              echo "Error: Unable to extract old major version." >&2
+          else
+              echo "Old major: $old_major_value"
+              old_major=$old_major_value
+          fi
+
+          # Extracting the new major version using grep
+          new_major_value=$(echo "$pr_title" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+          
+          # Check if the variable is empty
+          if [ -z "$new_major_value" ]; then
+              echo "Error: Unable to extract new major version." >&2
+          else
+              echo "New major: $new_major_value"
+              new_major=$new_major_value
+          fi
+        }
+
         isDependabot=${{ env.IS_DEPENDABOT }}
         isMajorUpdate=false
-        if [[ $isDependabot == "true" ]]
+        if [[ $isDependabot == "false" ]]
         then
-          update_string="${{ env.PR_TITLE }}"
-
-          old_version=$(echo "$update_string" | awk '{match($0, /[0-9]+(\.[0-9]+)*/, arr); print arr[0]}')
-          new_version=$(echo "$update_string" | awk '{match($0, /to [0-9]+(\.[0-9]+)*/, arr); gsub("to ", "", arr[0]); print arr[0]}')
-
-          old_major=$(echo "$old_version" | cut -d. -f1)
-          new_major=$(echo "$new_version" | cut -d. -f1)
-
-          echo "Old major: $old_major"
-          echo "New major: $new_major"
+          pr_title="${{ env.PR_TITLE }}"
+          extractMajorVersions "$pr_title"
 
           if [ "$old_major" != "$new_major" ]; then
             isMajorUpdate=true

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -62,8 +62,11 @@ runs:
     - name: Decide if Jira issue should be created
       id: should-create-jira-issue
       env:
-        IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
-        IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
+        # TODO: revert before merge
+        #IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
+        IS_TEAM_MEMBER: false
+        #IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
+        IS_DEPENDABOT_PULL_REQUEST: true
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
         SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES: ${{ inputs.should-notify-about-major-dependency-updates }}
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -80,21 +80,29 @@ runs:
           exit
         fi
 
-        update_string="${{ env.PR_TITLE }}"
-
-        old_version=$(echo "$update_string" | awk '{match($0, /[0-9]+(\.[0-9]+)*/, arr); print arr[0]}')
-        new_version=$(echo "$update_string" | awk '{match($0, /to [0-9]+(\.[0-9]+)*/, arr); gsub("to ", "", arr[0]); print arr[0]}')
-
-        old_major=$(echo "$old_version" | cut -d. -f1)
-        new_major=$(echo "$new_version" | cut -d. -f1)
-
+        isDependabot=${{ env.IS_DEPENDABOT }}
         isMajorUpdate=false
-        if [ "$old_major" != "$new_major" ]; then
-          isMajorUpdate=true
+        if [[ $isDependabot == "true" ]]
+        then
+          update_string="${{ env.PR_TITLE }}"
+
+          old_version=$(echo "$update_string" | awk '{match($0, /[0-9]+(\.[0-9]+)*/, arr); print arr[0]}')
+          new_version=$(echo "$update_string" | awk '{match($0, /to [0-9]+(\.[0-9]+)*/, arr); gsub("to ", "", arr[0]); print arr[0]}')
+
+          old_major=$(echo "$old_version" | cut -d. -f1)
+          new_major=$(echo "$new_version" | cut -d. -f1)
+
+          echo "Old major: $old_major"
+          echo "New major: $new_major"
+
+          if [ "$old_major" != "$new_major" ]; then
+            isMajorUpdate=true
+          fi
+
+          echo "Major update: $isMajorUpdate"
         fi
 
         isTeamMember=${{ env.IS_TEAM_MEMBER }}
-        isDependabot=${{ env.IS_DEPENDABOT }}
         notifyAboutMajorDependabotUpdates=${{ env.NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
         if [[ $notifyAboutMajorDependabotUpdates == "true" && $isDependabot == "true" ]]; then
           if [[ $isMajorUpdate == "true" ]]; then

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -18,9 +18,9 @@ inputs:
   github-token:
     required: true
     description: Token for authorization
-  notify-about-major-dependabot-updates:
+  should-notify-about-major-dependabot-updates:
     required: false
-    description: Notify about major dependabot updates
+    description: Specifies if action should create Jira issues for major dependency update pull requests from dependabot
     type: boolean
     default: false
 
@@ -47,130 +47,114 @@ runs:
 
     - name: Check if PR comes fron dependabot
       env:
-        IS_DEPENDABOT: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'dependabot[bot]' }}
-      id: is-dependabot
+        IS_DEPENDABOT_PULL_REQUEST: ${{ fromJson(steps.get-pr.outputs.data).user.login == 'dependabot[bot]' }}
+      id: is-dependabot-pull-request
       shell: bash
       run: |
-        echo "result=${{ env.IS_DEPENDABOT }}" >> $GITHUB_OUTPUT
+        echo "result=${{ env.IS_DEPENDABOT_PULL_REQUEST }}" >> $GITHUB_OUTPUT
 
     - name: Check if Jira issue already exists
-      id: jira-issue-already-exists
+      id: jira-ticket-already-exists
       shell: bash
       run: |
         echo "result=${{ contains(github.event.pull_request.labels.*.name, 'contribution') }}" >> $GITHUB_OUTPUT
 
     - name: Decide if Jira ticket should be created
-      id: create-jira-issue
+      id: should-create-jira-issue
       env:
         IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
-        IS_DEPENDABOT: ${{ steps.is-dependabot.outputs.result }}
+        IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
-        NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.notify-about-major-dependabot-updates }}
-        JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
+        SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.should-notify-about-major-dependabot-updates }}
+        JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-ticket-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash
       run: |
-        echo "Checking if Jira ticket already exists or PR is a draft"
+        # No need to create Jira issue if it already exists
         jiraIssueAlreadyExists=${{ env.JIRA_ISSUE_ALREADY_EXISTS }}
-        isDraft=${{ env.IS_DRAFT }}
-        if [[ jiraIssueAlreadyExists == "true" || isDraft == "true" ]]
-        then
-          echo "Jira ticket already exists or PR is a draft, exiting"
+        if [[ jiraIssueAlreadyExists == "true" ]]; then
+          echo "Jira issue already exists"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
-        # Define function to extract major versions from PR title
-        old_major=""
-        new_major=""
-        extractMajorVersions() {
-          echo "Checking if PR is a major update, PR title: $pr_title"
-
-          # Assign function parameter to a variable
-          pr_title=$1
-
-          # Extract number version using grep utility
-          #   - "--only-matching" prints only the matched (non-empty) parts of a matching line
-          #   - "--extended-regexp" allows to use extended regular expressions
-          #   - "cut -d' ' -f2" extracts the second word from the matched line
-          #   - "cut -d'.' -f1" extracts the first part of the version number
-          old_major_value=$(echo "$pr_title" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-
-          # Check if the variable is empty
-          if [ -z "$old_major_value" ]; then
-              echo "Error: Unable to extract old major version." >&2
-          else
-              echo "Old major: $old_major_value"
-              old_major=$old_major_value
-          fi
-
-          # Extracting the new major version using grep
-          new_major_value=$(echo "$pr_title" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-          
-          # Check if the variable is empty
-          if [ -z "$new_major_value" ]; then
-              echo "Error: Unable to extract new major version." >&2
-          else
-              echo "New major: $new_major_value"
-              new_major=$new_major_value
-          fi
-        }
-
-        # TODO: Revert it to getting value from env.IS_DEPENDABOT before merge
-        # isDependabot=${{ env.IS_DEPENDABOT }}
-        isDependabot=true
-
-        isMajorUpdate=false
-        if [[ $isDependabot == "true" ]]; then
-          echo "It is dependabot PR"
-          pr_title="${{ env.PR_TITLE }}"
-          extractMajorVersions "$pr_title"
-
-          if [ "$old_major" != "$new_major" ]; then
-            isMajorUpdate=true
-          fi
-
-          echo "Major update: $isMajorUpdate"
-        fi
-
-        isTeamMember=${{ env.IS_TEAM_MEMBER }}
-        notifyAboutMajorDependabotUpdates=${{ env.NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
-        if [[ $isDependabot == "true" ]]; then
-          if [[ $notifyAboutMajorDependabotUpdates == "true" ]]; then
-            if [[ $isMajorUpdate == "true" ]]; then
-              echo "Major dependabot update, exiting"
-              echo "result=true" >> $GITHUB_OUTPUT
-            else
-              echo "Non-major dependabot update (create-jira-issue: false), exiting"
-              echo "result=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No notifications for dependabot updates (create-jira-issue: false), exiting"
-            echo "result=false" >> $GITHUB_OUTPUT
-          fi
-
+        # No need to create Jira issue if pull request is a draft
+        isDraft=${{ env.IS_DRAFT }}
+        if [[ jiraIssueAlreadyExists == "true" || isDraft == "true" ]]; then
+          echo "Pull request is a draft"
+          echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
-        if [[ $isTeamMember == "false" ]]; then
-          echo "Author is not a member of the team (create-jira-issue: true), exiting"
+
+        # TODO: Revert it to getting value from env.IS_DEPENDABOT_PULL_REQUEST before merge
+        # isDependabotPullRequest=${{ env.IS_DEPENDABOT_PULL_REQUEST }}
+        isDependabotPullRequest=true
+
+
+        isTeamMember=${{ env.IS_TEAM_MEMBER }}
+        if [[ $isDependabotPullRequest == "false" ]]; then
+          if [[ $isTeamMember == "true" ]]; then
+            echo "Pull request author is member of the team"
+            echo "result=false" >> $GITHUB_OUTPUT
+            exit
+          fi
+
+          echo "Pull request author is not a member of the team"
           echo "result=true" >> $GITHUB_OUTPUT
           exit
         fi
 
-        echo "Exiting (create-jira-issue: false)"
-        echo "result=false" >> $GITHUB_OUTPUT
+        shouldNotifyAboutMajorDependabotUpdates=${{ env.SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES }}
+        if [[ $shouldNotifyAboutMajorDependabotUpdates == "false" ]]; then
+          echo "No need to notify about dependabot pull requests, exiting"
+          echo "result=false" >> $GITHUB_OUTPUT
+          exit
+        fi
+
+        oldMajor=""
+        newMajor=""
+        extractMajorVersionsFromTitle() {
+          pullRequestTitle=$1
+          echo "Checking if PR is a major update, PR title: $pullRequestTitle"
+
+          # Extract number version using grep utility
+          # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+          oldMajor=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+          if [ -z "$oldMajor" ]; then
+            echo "Error: Unable to extract old major version" >&2
+            exit 1
+          fi
+
+          # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+          newMajor=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+          if [ -z "$newMajor_value" ]; then
+            echo "Error: Unable to extract new major version" >&2
+            exit 1
+          fi
+        }
+
+        pullRequestTitle="${{ env.PR_TITLE }}"
+        extractMajorVersionsFromTitle "$pullRequestTitle"
+        if [ "$oldMajor" == "$newMajor" ]; then
+          echo "Is not a major update"
+          echo "result=false" >> $GITHUB_OUTPUT
+          exit
+        fi
+
+        echo "Is major dependabot pull request"
+        echo "result=true" >> $GITHUB_OUTPUT
 
     # Create JIRA issue
     - name: Add label - JIRA issue created - for non-Draft PR
-      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true }}
+      if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
       uses: andymckay/labeler@1.0.4
       with:
         repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
 
     - name: Create JIRA ticket
-      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true }}
+      if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
       shell: bash
       env:
         JIRA_HOOK: ${{ inputs.jira-hook }}
@@ -183,7 +167,7 @@ runs:
       run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
-      if: ${{ fromJson(steps.create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot.outputs.result) == false }}
+      if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot-pull-request.outputs.result) == false }}
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -69,68 +69,7 @@ runs:
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash
-      run: |
-        jiraIssueAlreadyExists=${{ env.JIRA_ISSUE_ALREADY_EXISTS }}
-        if [[ $jiraIssueAlreadyExists == "true" ]]; then
-          echo "Jira issue already exists"
-          echo "result=false" >> $GITHUB_OUTPUT
-          exit
-        fi
-
-        isDraft=${{ env.IS_DRAFT }}
-        if [[ $isDraft == "true" ]]; then
-          echo "Pull request is a draft"
-          echo "result=false" >> $GITHUB_OUTPUT
-          exit
-        fi
-
-        # Exit early if pull request is not from dependabot
-        isDependabotPullRequest=${{ env.IS_DEPENDABOT_PULL_REQUEST }}
-        if [[ $isDependabotPullRequest == "false" ]]; then
-          isTeamMember=${{ env.IS_TEAM_MEMBER }}
-          if [[ $isTeamMember == "true" ]]; then
-            echo "Pull request author is member of ${{ inputs.team }}"
-            echo "result=false" >> $GITHUB_OUTPUT
-            exit
-          fi
-
-          echo "Pull request author is not a member of ${{ inputs.team }}"
-          echo "result=true" >> $GITHUB_OUTPUT
-          exit
-        fi
-
-        shouldNotifyAboutMajorDependencyUpdates=${{ env.SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES }}
-        if [[ $shouldNotifyAboutMajorDependencyUpdates == "false" ]]; then
-          echo "No need to notify about dependency updates"
-          echo "result=false" >> $GITHUB_OUTPUT
-          exit
-        fi
-
-        pullRequestTitle="${{ env.PR_TITLE }}"
-
-        # Extract major versions using grep utility
-        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
-        currentMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-        if [ -z "$currentMajorVersion" ]; then
-          echo "Error: Unable to extract current major version" >&2
-          exit 1
-        fi
-
-        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "6"
-        newMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-        if [ -z "$newMajorVersion" ]; then
-          echo "Error: Unable to extract new major version" >&2
-          exit 1
-        fi
-
-        if [ "$currentMajorVersion" == "$newMajorVersion" ]; then
-          echo "Is not a major dependency update"
-          echo "result=false" >> $GITHUB_OUTPUT
-          exit
-        fi
-
-        echo "Is major dependency update"
-        echo "result=true" >> $GITHUB_OUTPUT
+      run: bash ${{ github.action_path }}/should-create-jira-issue.sh
 
     - name: Add contribution label to pull request
       if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -116,10 +116,12 @@ runs:
           fi
         }
 
-        isDependabot=${{ env.IS_DEPENDABOT }}
+        # TODO: Revert it to getting value from env.IS_DEPENDABOT before merge
+        # isDependabot=${{ env.IS_DEPENDABOT }}
+        isDependabot=true
+
         isMajorUpdate=false
-        # TODO: REVERT IT TO TRUE
-        if [[ $isDependabot == "false" ]]; then
+        if [[ $isDependabot == "true" ]]; then
           echo "It is dependabot PR"
           pr_title="${{ env.PR_TITLE }}"
           extractMajorVersions "$pr_title"

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -84,13 +84,8 @@ runs:
           exit
         fi
 
-
-        # TODO: Revert it to getting value from env.IS_DEPENDABOT_PULL_REQUEST before merge
-        # isDependabotPullRequest=${{ env.IS_DEPENDABOT_PULL_REQUEST }}
-        isDependabotPullRequest=true
-
-
         # Exit early if pull request is not from dependabot
+        isDependabotPullRequest=${{ env.IS_DEPENDABOT_PULL_REQUEST }}
         if [[ $isDependabotPullRequest == "false" ]]; then
           isTeamMember=${{ env.IS_TEAM_MEMBER }}
           if [[ $isTeamMember == "true" ]]; then

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -132,27 +132,25 @@ runs:
         echo "Is major dependency update"
         echo "result=true" >> $GITHUB_OUTPUT
 
-    # Create JIRA issue
-    - name: Add label - JIRA issue created - for non-Draft PR
+    - name: Add contribution label to pull request
       if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
       uses: andymckay/labeler@1.0.4
       with:
         repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
 
-    # TODO: uncomment it
-    # - name: Create Jira issue
-    #   if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
-    #   shell: bash
-    #   env:
-    #     JIRA_HOOK: ${{ inputs.jira-hook }}
-    #     REPO: ${{ inputs.repo }}
-    #     TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
-    #     AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
-    #     AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
-    #     NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
-    #     URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
-    #   run: bash ${{ github.action_path }}/notify-jira.sh
+    - name: Create JIRA issue
+      if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
+      shell: bash
+      env:
+        JIRA_HOOK: ${{ inputs.jira-hook }}
+        REPO: ${{ inputs.repo }}
+        TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
+        AUTHOR: ${{ fromJson(steps.get-pr.outputs.data).user.login }}
+        AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
+        NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
+        URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
+      run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author
       if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true && fromJson(steps.is-dependabot-pull-request.outputs.result) == false }}

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -92,8 +92,9 @@ runs:
         isDependabotPullRequest=true
 
 
-        isTeamMember=${{ env.IS_TEAM_MEMBER }}
+        # Exit early if pull request is not from dependabot
         if [[ $isDependabotPullRequest == "false" ]]; then
+          isTeamMember=${{ env.IS_TEAM_MEMBER }}
           if [[ $isTeamMember == "true" ]]; then
             echo "Pull request author is member of the team"
             echo "result=false" >> $GITHUB_OUTPUT
@@ -134,15 +135,14 @@ runs:
           fi
         }
 
-        pullRequestTitle="${{ env.PR_TITLE }}"
-        extractMajorVersionsFromTitle "$pullRequestTitle"
+        extractMajorVersionsFromTitle "${{ env.PR_TITLE }}"
         if [ "$oldMajor" == "$newMajor" ]; then
-          echo "Is not a major update"
+          echo "Is not a major dependency update pull request"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
         fi
 
-        echo "Is major dependabot pull request"
+        echo "Is major dependency update pull request"
         echo "result=true" >> $GITHUB_OUTPUT
 
     # Create JIRA issue

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -118,8 +118,10 @@ runs:
 
         isDependabot=${{ env.IS_DEPENDABOT }}
         isMajorUpdate=false
+        # TODO: REVERT IT TO TRUE
         if [[ $isDependabot == "false" ]]
         then
+          echo "It is dependabot PR"
           pr_title="${{ env.PR_TITLE }}"
           extractMajorVersions "$pr_title"
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -54,19 +54,19 @@ runs:
         echo "result=${{ env.IS_DEPENDABOT_PULL_REQUEST }}" >> $GITHUB_OUTPUT
 
     - name: Check if Jira issue already exists
-      id: jira-ticket-already-exists
+      id: jira-issue-already-exists
       shell: bash
       run: |
         echo "result=${{ contains(github.event.pull_request.labels.*.name, 'contribution') }}" >> $GITHUB_OUTPUT
 
-    - name: Decide if Jira ticket should be created
+    - name: Decide if Jira issue should be created
       id: should-create-jira-issue
       env:
         IS_TEAM_MEMBER: ${{ fromJson(steps.is-team-member.outputs.result) }}
         IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
         SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDABOT_UPDATES: ${{ inputs.should-notify-about-major-dependabot-updates }}
-        JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-ticket-already-exists.outputs.result }}
+        JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash
       run: |
@@ -113,30 +113,25 @@ runs:
           exit
         fi
 
-        oldMajor=""
-        newMajor=""
-        extractMajorVersionsFromTitle() {
-          pullRequestTitle=$1
-          echo "Checking if PR is a major update, PR title: $pullRequestTitle"
+        pullRequestTitle="${{ env.PR_TITLE }}"
 
-          # Extract number version using grep utility
-          # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
-          oldMajor=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-          if [ -z "$oldMajor" ]; then
-            echo "Error: Unable to extract old major version" >&2
-            exit 1
-          fi
+        # Extract major version using grep utility
+        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+        oldMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+        if [ -z "$oldMajorVersion" ]; then
+          echo "Error: Unable to extract old major version" >&2
+          exit 1
+        fi
 
-          # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
-          newMajor=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
-          if [ -z "$newMajor_value" ]; then
-            echo "Error: Unable to extract new major version" >&2
-            exit 1
-          fi
-        }
+        # Extract major version using grep utility
+        # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+        newMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+        if [ -z "$newMajorVersion" ]; then
+          echo "Error: Unable to extract new major version" >&2
+          exit 1
+        fi
 
-        extractMajorVersionsFromTitle "${{ env.PR_TITLE }}"
-        if [ "$oldMajor" == "$newMajor" ]; then
+        if [ "$oldMajorVersion" == "$newMajorVersion" ]; then
           echo "Is not a major dependency update pull request"
           echo "result=false" >> $GITHUB_OUTPUT
           exit
@@ -153,7 +148,7 @@ runs:
         repo-token: ${{ inputs.github-token }}
         add-labels: "contribution"
 
-    - name: Create JIRA ticket
+    - name: Create Jira issue
       if: ${{ fromJson(steps.should-create-jira-issue.outputs.result) == true }}
       shell: bash
       env:

--- a/notify-jira-about-contribution/should-create-jira-issue.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.sh
@@ -47,12 +47,12 @@ isDependabotPullRequest=$IS_DEPENDABOT_PULL_REQUEST
 if [[ $isDependabotPullRequest == "false" ]]; then
   isTeamMember=$IS_TEAM_MEMBER
   if [[ $isTeamMember == "true" ]]; then
-    echo "Pull request author is member of ${{ inputs.team }}"
+    echo "Pull request author is member of specified team"
     echo "result=false" >> $GITHUB_OUTPUT
     exit
   fi
 
-  echo "Pull request author is not a member of ${{ inputs.team }}"
+  echo "Pull request author is not a member of specified team"
   echo "result=true" >> $GITHUB_OUTPUT
   exit
 fi

--- a/notify-jira-about-contribution/should-create-jira-issue.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.sh
@@ -1,0 +1,91 @@
+if [[ -z $JIRA_ISSUE_ALREADY_EXISTS ]]; then
+  echo "Error: JIRA_ISSUE_ALREADY_EXISTS environment variable is not set" >&2
+  exit 1
+fi
+
+if [[ -z $IS_DRAFT ]]; then
+  echo "Error: IS_DRAFT environment variable is not set" >&2
+  exit 1
+fi
+
+if [[ -z $IS_TEAM_MEMBER ]]; then
+  echo "Error: IS_TEAM_MEMBER environment variable is not set" >&2
+  exit 1
+fi
+
+if [[ -z $IS_DEPENDABOT_PULL_REQUEST ]]; then
+  echo "Error: IS_DEPENDABOT_PULL_REQUEST environment variable is not set" >&2
+  exit 1
+fi
+
+if [[ -z $SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES ]]; then
+  echo "Error: SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES environment variable is not set" >&2
+  exit 1
+fi
+
+if [[ -z $PR_TITLE ]]; then
+  echo "Error: PR_TITLE environment variable is not set" >&2
+  exit 1
+fi
+
+jiraIssueAlreadyExists=$JIRA_ISSUE_ALREADY_EXISTS
+if [[ $jiraIssueAlreadyExists == "true" ]]; then
+  echo "Jira issue already exists"
+  echo "result=false" >> $GITHUB_OUTPUT
+  exit
+fi
+
+isDraft=$IS_DRAFT
+if [[ $isDraft == "true" ]]; then
+  echo "Pull request is a draft"
+  echo "result=false" >> $GITHUB_OUTPUT
+  exit
+fi
+
+# Exit early if pull request is not from dependabot
+isDependabotPullRequest=$IS_DEPENDABOT_PULL_REQUEST
+if [[ $isDependabotPullRequest == "false" ]]; then
+  isTeamMember=$IS_TEAM_MEMBER
+  if [[ $isTeamMember == "true" ]]; then
+    echo "Pull request author is member of ${{ inputs.team }}"
+    echo "result=false" >> $GITHUB_OUTPUT
+    exit
+  fi
+
+  echo "Pull request author is not a member of ${{ inputs.team }}"
+  echo "result=true" >> $GITHUB_OUTPUT
+  exit
+fi
+
+shouldNotifyAboutMajorDependencyUpdates=$SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES
+if [[ $shouldNotifyAboutMajorDependencyUpdates == "false" ]]; then
+  echo "No need to notify about dependency updates"
+  echo "result=false" >> $GITHUB_OUTPUT
+  exit
+fi
+
+pullRequestTitle=$PR_TITLE
+
+# Extract major versions using grep utility
+# For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
+currentMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+if [ -z "$currentMajorVersion" ]; then
+  echo "Error: Unable to extract current major version" >&2
+  exit 1
+fi
+
+# For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "6"
+newMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'to [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)
+if [ -z "$newMajorVersion" ]; then
+  echo "Error: Unable to extract new major version" >&2
+  exit 1
+fi
+
+if [ "$currentMajorVersion" == "$newMajorVersion" ]; then
+  echo "Is not a major dependency update"
+  echo "result=false" >> $GITHUB_OUTPUT
+  exit
+fi
+
+echo "Is major dependency update"
+echo "result=true" >> $GITHUB_OUTPUT

--- a/notify-jira-about-contribution/should-create-jira-issue.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.sh
@@ -42,24 +42,24 @@ if [[ $isDraft == "true" ]]; then
   exit
 fi
 
+isTeamMember=$IS_TEAM_MEMBER
+if [[ $isTeamMember == "true" ]]; then
+  echo "Pull request author is member of specified team"
+  echo "result=false" >> $GITHUB_OUTPUT
+  exit
+fi
+
 # Exit early if pull request is not from dependabot
 isDependabotPullRequest=$IS_DEPENDABOT_PULL_REQUEST
 if [[ $isDependabotPullRequest == "false" ]]; then
-  isTeamMember=$IS_TEAM_MEMBER
-  if [[ $isTeamMember == "true" ]]; then
-    echo "Pull request author is member of specified team"
-    echo "result=false" >> $GITHUB_OUTPUT
-    exit
-  fi
-
-  echo "Pull request author is not a member of specified team"
+  echo "Pull request author is not a dependabot and not a member of specified team"
   echo "result=true" >> $GITHUB_OUTPUT
   exit
 fi
 
 shouldNotifyAboutMajorDependencyUpdates=$SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES
 if [[ $shouldNotifyAboutMajorDependencyUpdates == "false" ]]; then
-  echo "No need to notify about dependency updates"
+  echo "Although ths is dependency update, notifying about major dependency updates is turned off"
   echo "result=false" >> $GITHUB_OUTPUT
   exit
 fi
@@ -82,7 +82,7 @@ if [ -z "$newMajorVersion" ]; then
 fi
 
 if [ "$currentMajorVersion" == "$newMajorVersion" ]; then
-  echo "Is not a major dependency update"
+  echo "It is minor or patch dependency update, no ticket is created"
   echo "result=false" >> $GITHUB_OUTPUT
   exit
 fi

--- a/notify-jira-about-contribution/should-create-jira-issue.test.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.test.sh
@@ -1,0 +1,88 @@
+# How to test
+# 1. Navigate to this folder
+# 2. Run `sh should-create-jira-issue.test.sh`
+
+# Temporary file that contains the output of the script
+export GITHUB_OUTPUT="./github-output.txt"
+
+function beforeEach {
+  rm -f $GITHUB_OUTPUT
+
+  export JIRA_ISSUE_ALREADY_EXISTS=false
+  export IS_DRAFT=false
+  export IS_TEAM_MEMBER=false
+  export IS_DEPENDABOT_PULL_REQUEST=false
+  export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=false
+  export PR_TITLE="Test value"
+}
+
+function afterAll {
+  rm -f $GITHUB_OUTPUT
+}
+
+function test {
+  expectedOutput=$1
+  expectedResult=$2
+
+  output=$(sh should-create-jira-issue.sh)
+  if [[ $output != $expectedOutput ]]; then
+    echo "Test failed: Invalid output, expected $expectedOutput but got $output"
+    exit 1
+  fi
+  if ! grep -q "result=$expectedResult" "$GITHUB_OUTPUT"; then
+    echo "Test failed: Expected result=$expectedResult not found in $GITHUB_OUTPUT"
+    exit 1
+  fi
+}
+
+beforeEach
+export JIRA_ISSUE_ALREADY_EXISTS=true
+echo "=== Case: Jira issue already exists"
+test "Jira issue already exists" "false"
+
+beforeEach
+export IS_DRAFT=true
+echo "=== Case: pull request is draft"
+test "Pull request is a draft" "false"
+
+beforeEach
+export IS_DEPENDABOT_PULL_REQUEST=true
+export PR_TITLE="Bump lodash from 4.17.20 to 4.17.21"
+export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=false
+echo "=== Case: non-major dependabot pull request, dependabot notifications disabled"
+test "No need to notify about dependency updates" "false"
+
+beforeEach
+export IS_DEPENDABOT_PULL_REQUEST=true
+export PR_TITLE="Bump lodash from 4.17.20 to 4.17.21"
+export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
+echo "=== Case: non-major dependabot pull request, dependabot notifications enabled"
+test "Is not a major dependency update" "false"
+
+beforeEach
+versionBump="from 4.17.20 to 5.17.21"
+export IS_DEPENDABOT_PULL_REQUEST=true
+export PR_TITLE="Bump lodash $versionBump"
+export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
+echo "=== Case: major dependabot pull request ($versionBump), dependabot notifications enabled"
+test "Is major dependency update" "true"
+
+beforeEach
+versionBump="from 4.4 to 7363638339"
+export IS_DEPENDABOT_PULL_REQUEST=true
+export PR_TITLE="Bump lodash $versionBump"
+export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
+echo "=== Case: major dependabot pull request ($versionBump), dependabot notifications enabled"
+test "Is major dependency update" "true"
+
+beforeEach
+export IS_TEAM_MEMBER=false
+echo "=== Case: pull request author is not a member of the team"
+test "Pull request author is not a member of specified team" "true"
+
+beforeEach
+export IS_TEAM_MEMBER=true
+echo "=== Case: pull request author is member of the team"
+test "Pull request author is member of specified team" "false"
+
+afterAll

--- a/notify-jira-about-contribution/should-create-jira-issue.test.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.test.sh
@@ -50,14 +50,14 @@ export IS_DEPENDABOT_PULL_REQUEST=true
 export PR_TITLE="Bump lodash from 4.17.20 to 4.17.21"
 export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=false
 echo "=== Case: non-major dependabot pull request, dependabot notifications disabled"
-test "No need to notify about dependency updates" "false"
+test "Although ths is dependency update, notifying about major dependency updates is turned off" "false"
 
 beforeEach
 export IS_DEPENDABOT_PULL_REQUEST=true
 export PR_TITLE="Bump lodash from 4.17.20 to 4.17.21"
 export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
 echo "=== Case: non-major dependabot pull request, dependabot notifications enabled"
-test "Is not a major dependency update" "false"
+test "It is minor or patch dependency update, no ticket is created" "false"
 
 beforeEach
 versionBump="from 4.17.20 to 5.17.21"
@@ -78,7 +78,7 @@ test "Is major dependency update" "true"
 beforeEach
 export IS_TEAM_MEMBER=false
 echo "=== Case: pull request author is not a member of the team"
-test "Pull request author is not a member of specified team" "true"
+test "Pull request author is not a dependabot and not a member of specified team" "true"
 
 beforeEach
 export IS_TEAM_MEMBER=true


### PR DESCRIPTION
[FX-4878]

### Description

This pull request fixes and comments the way major versions are detected for dependabot pull requests in `notify-jira-about-contribution` action. The problem was that the previous way was not working on company runners due to mismatch in `awk` implementation.


### How to test

- Rerun https://github.com/toptal/davinci/actions/runs/7846448583 action that uses latest version of branch from this pull request
- Test bash script at https://www.tutorialspoint.com/execute_bash_online.php

```bash
function test {
    pullRequestTitle=$1
    jiraIssueAlreadyExists=false
    isDraft=false
    isTeamMember=false
    isDependabotPullRequest=true
    shouldNotifyAboutMajorDependencyUpdates=false
    

    # INSERT TESTED BASH CODE HERE (remove " >> $GITHUB_OUTPUT" and replace ${{ env.* }} calls beforehand)
}

test "[FX-123] Update davinci-github-actions from 21.2 to 221"
echo "--------"
test "[FX-123] Update davinci-github-actions from 21 to 2.123.12223"
echo "--------"
test "[FX-123] Update davinci-github-actions from 2.12 to 2.14.15"
echo "--------"
test " Update davincifrom-github-actions from 2 to 400"
echo "--------"
test "[FX-123] Update davinci-github-actions from 21e.2 to 221"
echo "--------"
test "23] Update davinci-github-actions from 21.2 tos 221"
```

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-123]: https://toptal-core.atlassian.net/browse/FX-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4878]: https://toptal-core.atlassian.net/browse/FX-4878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ