### PR TITLE
[CI] Make build-publish-alpha-package work with custom runners

### DIFF
--- a/.changeset/stupid-lions-obey.md
+++ b/.changeset/stupid-lions-obey.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- make build-publish-alpha-package action work with custom runners

--- a/build-publish-alpha-package/action.yml
+++ b/build-publish-alpha-package/action.yml
@@ -23,6 +23,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up node
+      uses: actions/setup-node@v3.2.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
     - name: Setup npm # Add our registry to npm config
       shell: bash
       env:
@@ -30,12 +35,7 @@ runs:
       run: |
         npm set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
 
-    - name: Set up node
-      uses: actions/setup-node@v3.2.0
-      with:
-        node-version: ${{ inputs.node-version }}
-
-    - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
+    - uses: toptal/davinci-github-actions/yarn-install@v12.8.1
 
     - name: Build package
       shell: bash


### PR DESCRIPTION
[CI-3174](https://toptal-core.atlassian.net/browse/CI-3174)


`build-publish-alpha-package`  [failed](https://github.com/toptal/caliber/actions/runs/7814915240/job/21317342062#step:12:37) when the workflow was switched to use custom runners.
I moved `actions/setup-node` step before the step that uses npm command. It's necessary because our custom runners doesn't have preinstalled node/npm.

### How to test

- I tested setting up node here: https://github.com/toptal/inf-toolbox/actions/workflows/test-davinci-alpha-package.yml

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[CI-3174]: https://toptal-core.atlassian.net/browse/CI-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ