### PR TITLE
Add npm proxy variable

### DIFF
--- a/.changeset/few-swans-rush.md
+++ b/.changeset/few-swans-rush.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+Add switch to disable NPM proxy trough organisational variable

--- a/.changeset/few-swans-rush.md
+++ b/.changeset/few-swans-rush.md
@@ -2,4 +2,4 @@
 'davinci-github-actions': patch
 ---
 
-Add switch to disable NPM proxy trough organisational variable
+- add switch to disable NPM proxy through organisational variable

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,6 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Test org env
+      shell: bash
       run: |
         echo "${{ vars.NPM_PROXY_RUNNER_NAME }}"
     - name: Create .npmrc file using npm Artifact Registry

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -92,10 +92,6 @@ runs:
 
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
-    - name: Test org env
-      shell: bash
-      run: |
-        echo "${{ vars.NPM_PROXY_RUNNER_NAME }}"
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,7 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'env.NPM_PROXY_RUNNER_NAME')"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
       run: |
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
@@ -110,7 +110,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'env.NPM_PROXY_RUNNER_NAME')"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
       run: |
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,7 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"
       run: |
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
@@ -110,7 +110,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"
       run: |
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,7 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'DISABLED')"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
       run: |
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
@@ -110,7 +110,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'DISABLED')"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
       run: |
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,7 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(env.NPM_PROXY_RUNNER_NAME, runner.name)"
       run: |
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
@@ -110,7 +110,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, env.NPM_PROXY_RUNNER_NAME)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(env.NPM_PROXY_RUNNER_NAME, runner.name)"
       run: |
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -92,10 +92,9 @@ runs:
 
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
-    - name: Test variables
+    - name: Test org env
       run: |
-        echo ${{ vars.NPM_PROXY_RUNNER_NAME }}
-        echo "runner name is ${{ runner.name }}"
+        echo "${{ vars.NPM_PROXY_RUNNER_NAME }}"
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -93,7 +93,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(env.NPM_PROXY_RUNNER_NAME, runner.name)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'env.NPM_PROXY_RUNNER_NAME')"
       run: |
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
@@ -110,7 +110,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && contains(env.NPM_PROXY_RUNNER_NAME, runner.name)"
+      if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, 'env.NPM_PROXY_RUNNER_NAME')"
       run: |
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -92,6 +92,10 @@ runs:
 
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
+    - name: Test variables
+      run: |
+        echo "${{ vars.NPM_PROXY_RUNNER_NAME }}"
+        echo "runner name is ${{ runner.name }}"
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -94,7 +94,7 @@ runs:
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Test variables
       run: |
-        echo "${{ vars.NPM_PROXY_RUNNER_NAME }}"
+        echo ${{ vars.NPM_PROXY_RUNNER_NAME }}
         echo "runner name is ${{ runner.name }}"
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && contains(runner.name, vars.NPM_PROXY_RUNNER_NAME)"


### PR DESCRIPTION
[CI-3182]

### Description

Adding npm proxy variable will allow us to turn off proxy if needed (by editing organisational variables)

Github variables are set same way as github secrets and they also can be overridden per repository. In this case disabling NPM proxy could be done on org level or only for specific repositories

More about variables here https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository

### How to test

Run any workflow using yarn-install

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[CI-3182]: https://toptal-core.atlassian.net/browse/CI-3182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ