### PR TITLE
[FX-4853] Add major-dependency-update-jira-label parameter

### DIFF
--- a/.changeset/shaggy-tigers-lie.md
+++ b/.changeset/shaggy-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add `major-dependency-update-jira-label` parameter to `notify-jira-about-contribution` action

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -10,14 +10,15 @@ Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
 
 The list of arguments, that are used in GH Action:
 
-| name                                           | type   | required | default | description                                                                                                                               |
-| ---------------------------------------------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `team`                                         | string | ✅        |         | Team that we are checking against                                                                                                         |
-| `repo`                                         | string | ✅        |         | Repository name                                                                                                                           |
-| `pull-number`                                  | string | ✅        |         | Nth pull request                                                                                                                          |
-| `jira-hook`                                    | string | ✅        |         | JIRA automation hook for contribution                                                                                                     |
-| `github-token`                                 | string | ✅        |         | Token for authorization                                                                                                                   |
-| `should-notify-about-major-dependency-updates` | string |          |         | Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored) |
+| name                                           | type   | required | default              | description                                                                                                                               |
+| ---------------------------------------------- | ------ | -------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `team`                                         | string | ✅        |                      | Team that we are checking against                                                                                                         |
+| `repo`                                         | string | ✅        |                      | Repository name                                                                                                                           |
+| `pull-number`                                  | string | ✅        |                      | Nth pull request                                                                                                                          |
+| `jira-hook`                                    | string | ✅        |                      | JIRA automation hook for contribution                                                                                                     |
+| `github-token`                                 | string | ✅        |                      | Token for authorization                                                                                                                   |
+| `should-notify-about-major-dependency-updates` | string |          |                      | Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored) |
+| `major-dependency-update-jira-label`           | string |          | ready-for-refinement | Label that is added if contribution is a dependency update                                                                                |
 
 ### Outputs
 

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored)
     type: boolean
     default: false
+  major-dependency-update-jira-label:
+    required: false
+    description: Label that is added if contribution is a dependency update
+    default: "ready-for-refinement"
 
 runs:
   using: composite
@@ -89,6 +93,7 @@ runs:
         AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
         NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
         URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
+        LABEL: ${{ fromJson(steps.is-dependabot-pull-request.outputs.result) == true && inputs.major-dependency-update-jira-label || "" }}
       run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -93,7 +93,7 @@ runs:
         AUTHOR_URL: ${{ fromJson(steps.get-pr.outputs.data).user.html_url }}
         NUMBER: ${{ fromJson(steps.get-pr.outputs.data).number }}
         URL: ${{ fromJson(steps.get-pr.outputs.data).html_url }}
-        LABEL: ${{ fromJson(steps.is-dependabot-pull-request.outputs.result) == true && inputs.major-dependency-update-jira-label || "" }}
+        LABEL: ${{ fromJson(steps.is-dependabot-pull-request.outputs.result) == true && inputs.major-dependency-update-jira-label || '' }}
       run: bash ${{ github.action_path }}/notify-jira.sh
 
     - name: Greet author

--- a/notify-jira-about-contribution/notify-jira.sh
+++ b/notify-jira-about-contribution/notify-jira.sh
@@ -12,7 +12,8 @@ generate_data()
       "title": "$TITLE",
       "number": "$NUMBER",
       "url": "$URL",
-      "repo": "$REPO"
+      "repo": "$REPO",
+      "label": "$LABEL"
     }
   }
 EOF


### PR DESCRIPTION
[FX-4853]

### Description

This pull request adds `major-dependency-update-jira-label` parameter to `notify-jira-about-contribution` action, so the label that is added to created Jira ticket can be configured for dependabot major updates.

https://toptal-core.atlassian.net/jira/software/c/projects/FX/settings/automate#/rule/3021227/403457150 automation was updated to take label into account

<img width="379" alt="Screenshot 2024-02-20 at 10 07 27" src="https://github.com/toptal/davinci-github-actions/assets/1390758/852d7c7a-be0f-4063-9eb4-a27788fbbf8e">

### How to test

- check out https://toptal-core.atlassian.net/browse/FX-4920 (result of https://github.com/toptal/staff-portal/pull/11734), it has `ready-for-refinement` label and it was not moved in **To Do** automatically due to changes in automation

<img width="1027" alt="Screenshot 2024-02-20 at 10 30 39" src="https://github.com/toptal/davinci-github-actions/assets/1390758/81428414-450a-44d2-af68-543e98ff5f94">



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4853]: https://toptal-core.atlassian.net/browse/FX-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ