### PR TITLE
[FX-4950] Make build-push-image action more reusable

### DIFF
--- a/.changeset/healthy-walls-judge.md
+++ b/.changeset/healthy-walls-judge.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add new options to build-push-release-image to support multi hosts in monorepo

--- a/build-push-release-image/README.md
+++ b/build-push-release-image/README.md
@@ -10,11 +10,13 @@ This GH Action builds a Docker [release image](https://github.com/toptal/davinci
 
 The list of arguments, that are used in GH Action:
 
-| name              | type                                                        | required | default | description                                                           |
-| ----------------- | ----------------------------------------------------------- | -------- | ------- | --------------------------------------------------------------------- |
-| `sha`             | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image           |
-| `repository-name` | string                                                      | ✅        |         | Name of repository. It's used to determine an image name              |
-| `environment`     | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Used to determine additional procedures while creating a Docker image |
+| name              | type                                                        | required | default | description                                                                                                         |
+| ----------------- | ----------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `sha`             | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image                                                         |
+| `repository-name` | string                                                      | ✅        |         | Name of repository. It's used to determine an image name                                                            |
+| `environment`     | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Used to determine additional procedures while creating a Docker image                                               |
+| `dist-folder`     | string                                                      |          | ./dist  | Path to the folder with the built project                                                                           |
+| `scope`           | string                                                      |          |         | Used to determine the scope of the built project. Usefull in multihost monorepo projects to build only one project. |
 
 ### Outputs
 

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -17,15 +17,31 @@ inputs:
     required: false
     default: staging
     description: Used to determine additional procedures while creating a Docker image || enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>>
+  dist-folder:
+    required: false
+    default: ./dist
+    description: Path to the folder with the built project
+  scope:
+    required: false
+    default: ''
+    description: Used to determine the scope of the built project. Usefull in multihost monorepo projects to build only one project.
 
 runs:
   using: composite
   steps:
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 
+    # Use yarn lerna run build --scope=${{ inputs.scope}} if the scope is set, otherwise use yarn build
     - name: Build
       shell: bash
-      run: yarn build
+      run: |
+        if [[ -z "${{ inputs.scope }}" ]]; then
+          yarn build
+        else
+          yarn lerna run build --scope=${{ inputs.scope}}
+        fi
+
+
 
     - uses: toptal/davinci-github-actions/build-push-image@v6.0.0
       with:
@@ -35,6 +51,6 @@ runs:
         docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
         build-args: |
           ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
-          DIST_FOLDER=./dist
+          DIST_FOLDER=${{ inputs.dist-folder }}
           NGINX_CONFIG=./davinci/packages/davinci/docker/nginx-vhost.conf
           VERSION=${{ inputs.sha }}

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -31,7 +31,6 @@ runs:
   steps:
     - uses: toptal/davinci-github-actions/yarn-install@v6.0.0
 
-    # Use yarn lerna run build --scope=${{ inputs.scope}} if the scope is set, otherwise use yarn build
     - name: Build
       shell: bash
       run: |
@@ -40,8 +39,6 @@ runs:
         else
           yarn lerna run build --scope=${{ inputs.scope}}
         fi
-
-
 
     - uses: toptal/davinci-github-actions/build-push-image@v6.0.0
       with:


### PR DESCRIPTION
[FX-4950]

### Description

To enable building docker images in multi host monorepo we need to add few more optional options.

### How to test

It is being use in https://github.com/toptal/client-portal/pull/8174

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4950]: https://toptal-core.atlassian.net/browse/FX-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ