### PR TITLE
[FX-4996] Add DAVINCI_DOCKER_BUILD env variable to build images

### DIFF
--- a/.changeset/metal-moose-cry.md
+++ b/.changeset/metal-moose-cry.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- add DAVINCI_DOCKER_BUILD env variable to build images

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -33,6 +33,8 @@ runs:
 
     - name: Build
       shell: bash
+      env:
+        DAVINCI_DOCKER_BUILD: true
       run: |
         if [[ -z "${{ inputs.scope }}" ]]; then
           yarn build


### PR DESCRIPTION
[FX-4996]

### Description

We need to specify a flag that highlights the Davinci Docker build

### How to test

- Run this GH Action

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4996]: https://toptal-core.atlassian.net/browse/FX-4996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ