### PR TITLE
Use single yarn.lock file to detect cache hit in yarn-install action

### DIFF
--- a/.changeset/little-suits-tease.md
+++ b/.changeset/little-suits-tease.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### yarn-install
+
+- fix using single yarn.lock file to detect cache hash in the root folder of the project, so reducing the time for action execution

--- a/.changeset/little-suits-tease.md
+++ b/.changeset/little-suits-tease.md
@@ -1,5 +1,5 @@
 ---
-'davinci-github-actions': patch
+'davinci-github-actions': major
 ---
 
 ---
@@ -7,3 +7,5 @@
 ### yarn-install
 
 - fix using single yarn.lock file to detect cache hash in the root folder of the project, so reducing the time for action execution
+
+BREAKING CHANGE: The action now uses a single yarn.lock located in the root of the repository to detect the cache hash. If you have multiple yarn.lock files in your repository, only the root one will be included in cache hash calculations.

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -70,7 +70,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
 
     - name: Cache yarn and node_modules folder
       if: "!contains(runner.name, 'inf-gha-runners-ci') || !inputs.checkout-token"
@@ -83,7 +83,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('**/yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
 
     - name: Delete temporary tmp-workspaces.json
       shell: bash


### PR DESCRIPTION
### Description

As you can see in the action https://github.com/toptal/client-portal/actions/runs/8602698307/job/23572835410#step:15:153 the action tries to find all yarn.lock files, including ones from the `node_modules` and `workflows` folders. Those are completely irrelevant. This creates performance issues and in some cases failure of the workflows, like in CP - https://github.com/toptal/client-portal/actions/runs/8602698307/job/23572952678

<img width="1416" alt="Screenshot 2024-04-08 at 19 38 57" src="https://github.com/toptal/davinci-github-actions/assets/2836281/8449c9e0-42f2-43b5-b44c-750524e9d678">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
