### PR TITLE
[FX-4986] throw error when there are uncommitted changes in the yarn.lock

### DIFF
--- a/.changeset/strange-garlics-fetch.md
+++ b/.changeset/strange-garlics-fetch.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+### yarn install action
+
+- throw an error when there is an uncommitted change in the yarn.lock

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -171,7 +171,7 @@ runs:
         sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#https://registry.yarnpkg.com/#g" ${{ inputs.path }}/yarn.lock
 
       # We are manually checking for the changes in yarn.lock file, because
-      # the `--frozen-lockfile` flag is not working in correctly in workspaces with yarn v1
+      # the `--frozen-lockfile` flag is not working correctly in workspaces with yarn v1
       # we can remove this step when we upgrade yarn or migrate to other package manager
     - name: Check for changes
       shell: bash

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -149,9 +149,14 @@ runs:
       run: |
         for i in {1..$MAX_ATTEMPTS}; do
           printf "Trying to install #%s...\n" "$i"
-          yarn install --frozen-lockfile --non-interactive && break
+          yarn install --non-interactive && break
           sleep 10 # 10s wait time
         done
+
+    - name: Check for changes
+      shell: bash
+      run: |
+        git diff --exit-code yarn.lock || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)
 
     # Revert the URLs to the original registry
     - name: Revert URLs to original registry

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -170,6 +170,9 @@ runs:
         # Revert the leftovers URLs to yarnpkg.org registry
         sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#https://registry.yarnpkg.com/#g" ${{ inputs.path }}/yarn.lock
 
+      # We are manually checking for the changes in yarn.lock file, because
+      # the `--frozen-lockfile` flag is not working in correctly in workspaces with yarn v1
+      # we can remove this step when we upgrade yarn or migrate to other package manager
     - name: Check for changes
       shell: bash
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -153,10 +153,7 @@ runs:
           sleep 10 # 10s wait time
         done
 
-    - name: Check for changes
-      shell: bash
-      run: |
-        git diff --exit-code yarn.lock || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)
+
 
     # Revert the URLs to the original registry
     - name: Revert URLs to original registry
@@ -172,3 +169,8 @@ runs:
 
         # Revert the leftovers URLs to yarnpkg.org registry
         sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#https://registry.yarnpkg.com/#g" ${{ inputs.path }}/yarn.lock
+
+    - name: Check for changes
+      shell: bash
+      run: |
+        git diff --exit-code yarn.lock || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)


### PR DESCRIPTION
[FX-4986]

### Description

throw an error when there are uncommitted changes in the yarn.lock

We tested that removing `--frozen-lockfile` flag has the same functionality, but updating the log file.

Tested scenarios:
- When we downgrade the library from v9 to v8 and run it with the flag, the lock file is not updated and in node modules, we have v8
- When we have in package.json `^8.0.0`, in the lock file we have `8.0.2`, and in npm, there is version `8.0.4`, after both installations, we still have `8.0.2` installed and yarn.lock is not updated. Even if we remove node_modules.
- We tested that `--frozen-lockfile` is not throwing the expected error, it is a known issue that is fixed in version 2+ and will not be backported to v1
- In the [test run](https://github.com/toptal/staff-portal/actions/runs/8661460851/job/23751676808) we can see in git diff that even in CI only expected changes appeared in yarn.lock

![image](https://github.com/toptal/davinci-github-actions/assets/6830426/27dc1289-ea98-4c0c-bffc-0fb71af372bc)


### How to test

- check the test in the Staff Portal https://github.com/toptal/staff-portal/actions/runs/8661460851/job/23751676808

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4986]: https://toptal-core.atlassian.net/browse/FX-4986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ