### PR TITLE
[FX-4986] Run check in the working environment

### DIFF
--- a/.changeset/wet-ants-count.md
+++ b/.changeset/wet-ants-count.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+### Yarn install
+
+- run the check for the uncommitted changes in working directory

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -175,5 +175,6 @@ runs:
       # we can remove this step when we upgrade yarn or migrate to other package manager
     - name: Check for changes
       shell: bash
+      working-directory: ${{ inputs.path }}
       run: |
         git diff --exit-code yarn.lock || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)


### PR DESCRIPTION
[FX-4986]

### Description

We forgot to add `working-directory` input in previous patch and it is making SP release to fail

### How to test

- FIXME: Add the steps describing how to verify your changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[FX-4986]: https://toptal-core.atlassian.net/browse/FX-4986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ