### PR TITLE
[Fx-NULL] Add ability to ignore certain major update packages

### DIFF
--- a/.changeset/tame-comics-agree.md
+++ b/.changeset/tame-comics-agree.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- do not create contribution tickets for major dependency updates that match the pattern

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -4,7 +4,7 @@ Notifies JIRA about external contribution
 
 ### Description
 
-Notifies JIRA about external contribution. Draft and dependabot PRs are ignored.
+Notifies JIRA about external contribution. Draft and dependabot PRs are ignored (unless `should-notify-about-major-dependency-updates` is set).
 
 ### Inputs
 
@@ -18,6 +18,7 @@ The list of arguments, that are used in GH Action:
 | `jira-hook`                                    | string | ✅        |                      | JIRA automation hook for contribution                                                                                                     |
 | `github-token`                                 | string | ✅        |                      | Token for authorization                                                                                                                   |
 | `should-notify-about-major-dependency-updates` | string |          |                      | Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored) |
+| `ignore-major-dependency-update-packages`      | string |          |                      | Regular expression for packages that should be ignored when creating Jira issues for major dependency updates                             |
 | `major-dependency-update-jira-label`           | string |          | ready-for-refinement | Label that is added if contribution is a dependency update                                                                                |
 
 ### Outputs

--- a/notify-jira-about-contribution/README.md
+++ b/notify-jira-about-contribution/README.md
@@ -18,7 +18,7 @@ The list of arguments, that are used in GH Action:
 | `jira-hook`                                    | string | ✅        |                      | JIRA automation hook for contribution                                                                                                     |
 | `github-token`                                 | string | ✅        |                      | Token for authorization                                                                                                                   |
 | `should-notify-about-major-dependency-updates` | string |          |                      | Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored) |
-| `ignore-major-dependency-update-packages`      | string |          |                      | Regular expression for packages that should be ignored when creating Jira issues for major dependency updates                             |
+| `ignore-major-dependency-update-packages`      | string |          | /@toptal/            | Regular expression for packages that should be ignored when creating Jira issues for major dependency updates                             |
 | `major-dependency-update-jira-label`           | string |          | ready-for-refinement | Label that is added if contribution is a dependency update                                                                                |
 
 ### Outputs

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -26,7 +26,7 @@ inputs:
   ignore-major-dependency-update-packages:
     required: false
     description: Regular expression for packages that should be ignored when creating Jira issues for major dependency updates
-    default: ""
+    default: "/@toptal/"
   major-dependency-update-jira-label:
     required: false
     description: Label that is added if contribution is a dependency update

--- a/notify-jira-about-contribution/action.yml
+++ b/notify-jira-about-contribution/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Specifies if action should create Jira issues for major dependency updates (authored by dependabot, minor and patch versions are ignored)
     type: boolean
     default: false
+  ignore-major-dependency-update-packages:
+    required: false
+    description: Regular expression for packages that should be ignored when creating Jira issues for major dependency updates
+    default: ""
   major-dependency-update-jira-label:
     required: false
     description: Label that is added if contribution is a dependency update
@@ -70,6 +74,7 @@ runs:
         IS_DEPENDABOT_PULL_REQUEST: ${{ steps.is-dependabot-pull-request.outputs.result }}
         IS_DRAFT: ${{ fromJson(steps.get-pr.outputs.data).draft }}
         SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES: ${{ inputs.should-notify-about-major-dependency-updates }}
+        IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES: ${{ inputs.ignore-major-dependency-update-packages || '/@toptal/' }}
         JIRA_ISSUE_ALREADY_EXISTS: ${{ steps.jira-issue-already-exists.outputs.result }}
         PR_TITLE: ${{ fromJson(steps.get-pr.outputs.data).title }}
       shell: bash

--- a/notify-jira-about-contribution/should-create-jira-issue.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.sh
@@ -66,6 +66,15 @@ fi
 
 pullRequestTitle=$PR_TITLE
 
+ignoreMajorDependencyUpdatePackages=$IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES
+if [[ -n "$IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES" ]]; then
+  if [[ "$pullRequestTitle" =~ $IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES ]]; then
+    echo "Although ths is dependency update and notifying about major dependency updates is turned on, the package is ignored"
+    echo "result=false" >> $GITHUB_OUTPUT
+    exit
+  fi
+fi
+
 # Extract major versions using grep utility
 # For "Bump @cypress/webpack-preprocessor from 5.17.1 to 6.0.1" it returns "5"
 currentMajorVersion=$(echo "$pullRequestTitle" | grep --only-matching --extended-regexp 'from [0-9]+(\.[0-9]+)?' | cut -d' ' -f2 | cut -d'.' -f1)

--- a/notify-jira-about-contribution/should-create-jira-issue.test.sh
+++ b/notify-jira-about-contribution/should-create-jira-issue.test.sh
@@ -13,6 +13,7 @@ function beforeEach {
   export IS_TEAM_MEMBER=false
   export IS_DEPENDABOT_PULL_REQUEST=false
   export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=false
+  export IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES=""
   export PR_TITLE="Test value"
 }
 
@@ -66,6 +67,15 @@ export PR_TITLE="Bump lodash $versionBump"
 export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
 echo "=== Case: major dependabot pull request ($versionBump), dependabot notifications enabled"
 test "Is major dependency update" "true"
+
+beforeEach
+versionBump="from 4.17.20 to 5.17.21"
+export IS_DEPENDABOT_PULL_REQUEST=true
+export PR_TITLE="Bump @toptal/davinci-github-actions $versionBump"
+export SHOULD_NOTIFY_ABOUT_MAJOR_DEPENDENCY_UPDATES=true
+export IGNORE_MAJOR_DEPENDENCY_UPDATE_PACKAGES="@toptal"
+echo "=== Case: major dependabot pull request ($versionBump), dependabot notifications enabled, package is ignored"
+test "Although ths is dependency update and notifying about major dependency updates is turned on, the package is ignored" "false"
 
 beforeEach
 versionBump="from 4.4 to 7363638339"


### PR DESCRIPTION
### Description

This pull request is a follow-up to the problems identified in https://toptal-core.slack.com/archives/GG3F4AS4T/p1717170652381949 – the pull request adds ability not to create tickets for major dependency update if they match a regexp (the default value is `/@toptal/`).

### How to test

- Please follow unit test instructions in https://github.com/toptal/davinci-github-actions/blob/FX-NULL-improve-contribution-notification/notify-jira-about-contribution/should-create-jira-issue.test.sh#L1

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
