### PR TITLE
[GE-1005] Fix node deprecation warnings in Yarn Install action

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Checkout `cache action` from actions repository
       if: "inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: toptal/actions
         token: ${{ inputs.checkout-token }}
@@ -74,7 +74,7 @@ runs:
 
     - name: Cache yarn and node_modules folder
       if: "!(inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204')))"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: node-modules-cache
       with:
         # Do not change the order of the values because if something goes wrong with the network or node_modules during


### PR DESCRIPTION
[GE-1005]

### Description

We are updating the `yarn-install` workflow as it's calling some outdated actions that use Node 16, which is causing some deprecation warnings as it has already reached it's EOL.

### How to test

- You can see the workflow that uses `yarn-install` passing [here](https://github.com/toptal/blackfish/actions/runs/9653485728/job/26626333348?pr=11166) with no deprecation warnings. For reference, you can compare against [this master run](https://github.com/toptal/blackfish/actions/runs/9650763863), which shows the deprecation warnings

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[GE-1005]: https://toptal-core.atlassian.net/browse/GE-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ