### PR TITLE
[GE-1029] Fix GHA Node deprecation warnings in build-push-image action

### DIFF
--- a/.changeset/wet-rivers-sparkle.md
+++ b/.changeset/wet-rivers-sparkle.md
@@ -2,4 +2,5 @@
 'davinci-github-actions': patch
 ---
 
-- update ssh-agent action version used in build-push-image
+- update `ssh-agent` action version used in build-push-image
+- update `github-script` action version used in extract-env-variables

--- a/.changeset/wet-rivers-sparkle.md
+++ b/.changeset/wet-rivers-sparkle.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': patch
+---
+
+- update ssh-agent action version used in build-push-image

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -102,7 +102,7 @@ runs:
           latest=${{ steps.meta-build.outputs.latest }}
 
     - name: Use SSH key
-      uses: toptal/ssh-agent@v0.4.1
+      uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ env.TOPTAL_BUILD_BOT_SSH_KEY }}
 

--- a/extract-env-variables/action.yml
+++ b/extract-env-variables/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Extract Env variables
       id: env-variables
-      uses: actions/github-script@v6.3.3
+      uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github-token }}
         result-encoding: string


### PR DESCRIPTION
[GE-1029]

### Description

We are updating the `ssh-agent` action version on the `build-push-image` action, as it's using Node 12

### How to test

- You can see the action working, without the deprecation warning, [in this run](https://github.com/toptal/frontier-pub/actions/runs/9714066603/job/26812388150?pr=7005)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>


[GE-1029]: https://toptal-core.atlassian.net/browse/GE-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ