### PR TITLE
[FX-NULL] Add automerge composite action

### DIFF
--- a/.changeset/sweet-pigs-rhyme.md
+++ b/.changeset/sweet-pigs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add `automerge-release-pr` composite action

--- a/automerge-release-pr/README.md
+++ b/automerge-release-pr/README.md
@@ -1,0 +1,22 @@
+## Automatically merge release pull request
+
+Automatically merges Version Packages pull requests to the main branch (for all types of releases – patch, minor, major).
+
+### Inputs
+
+The list of arguments, that are used in GH Action:
+
+| name        | type   | required | default | description                                             |
+| ----------- | ------ | -------- | ------- | ------------------------------------------------------- |
+| `token`     | string | ✅        |         | GitHub token to create a comment and merge pull request |
+| `pr-number` | string | ✅        |         | Pull request number                                     |
+
+### Outputs
+
+Not specified
+
+### Usage
+
+```yaml
+  - uses: toptal/davinci-github-actions/automerge-release-pr@v1.1.1
+```

--- a/automerge-release-pr/action.yml
+++ b/automerge-release-pr/action.yml
@@ -1,0 +1,37 @@
+name: Automatically merge release pull request
+description: |
+  Automatically merges Version Packages pull requests to the main branch (for all types of releases – patch, minor, major).
+
+inputs:
+  token:
+    required: true
+    description: GitHub token to create a comment and merge pull request
+  pr-number:
+    required: true
+    description: Pull request number
+
+runs:
+  using: composite
+  steps:
+    - name: Merge pull request
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.token }}
+        pr-number: 
+        script: |
+          const repository = context.repo
+          const commentBody = "This pull request will be merged automatically"
+
+          await github.rest.issues.createComment({
+            owner: repository.owner,
+            issue_number: ${{ inputs.pr-number }},
+            repo: repository.repo,
+            body: commentBody,
+          })
+
+          await github.rest.pulls.merge({
+            merge_method: "squash",
+            owner: repository.owner,
+            pull_number: ${{ inputs.pr-number }},
+            repo: repository.repo,
+          })

--- a/automerge-release-pr/action.yml
+++ b/automerge-release-pr/action.yml
@@ -17,7 +17,6 @@ runs:
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.token }}
-        pr-number: 
         script: |
           const repository = context.repo
           const commentBody = "This pull request will be merged automatically"


### PR DESCRIPTION
### Description

During one of Retro meetings we decided that we want to automerge major version packages pull requests in Frontend Experience products (minor and patch versions are already automerged).

While changing the logic I noticed that there is quite some duplication in three repos

- https://github.com/toptal/davinci/blob/master/.github/workflows/automerge-release.yaml
- https://github.com/toptal/topkit/blob/master/.github/workflows/automerge-release.yaml
- https://github.com/toptal/picasso/blob/master/.github/workflows/automerge-release.yaml

This pull request extracts automerge logic into composite action, so there is a single source of truth (DRY). If we want to change the logic later, it can be changed only in one place.

### How to test

The plan

- merge this pull request
- reuse action in Topkit
- make sure that it works
- reuse action in Picasso and Davinci

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
