### PR TITLE
[FX-NULL] Add gh-runners-driver-opts option

### DIFF
--- a/.changeset/long-poems-work.md
+++ b/.changeset/long-poems-work.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add `gh-runners-driver-opts` option to `build-push-image` action to allow using custom image for `buildx`

--- a/build-push-image/README.md
+++ b/build-push-image/README.md
@@ -12,22 +12,23 @@ This GH Action builds a Docker image and pushes to google cloud.
 
 The list of arguments, that are used in GH Action:
 
-| name               | type                                                        | required | default           | description                                                                                |
-| ------------------ | ----------------------------------------------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------ |
-| `sha`              | string                                                      |          | ${{ github.sha }} | Commit hash that will be used as a tag for the Docker image                                |
-| `image-name`       | string                                                      | ✅        |                   | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
-| `build-args`       | string                                                      |          |                   | Multiline string to describe build arguments that will be used during dockerization        |
-| `environment`      | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging           | Determines additional procedures while creating a Docker image.                            |
-| `docker-file`      | string                                                      |          | Dockerfile        | pathname to Dockerfile                                                                     |
-| `davinci-branch`   | string                                                      |          | master            | Custom davinci branch                                                                      |
-| `labels`           | string                                                      |          |                   | List of metadata for the Docker image                                                      |
-| `context`          | string                                                      |          | .                 | Build context                                                                              |
-| `push`             | string                                                      |          | true              | Push the image to the registry                                                             |
-| `platforms`        | string                                                      |          | linux/amd64       | List of target platforms for build                                                         |
-| `tags`             | string                                                      |          |                   | Additional tags for the Docker image                                                       |
-| `target`           | string                                                      |          |                   | Sets the target stage to build                                                             |
-| `checkout-davinci` | string                                                      |          | false             | Checkout davinci repository                                                                |
-| `registry-name`    | string                                                      | ✅        |                   | Registry to push the builded image                                                         |
+| name                    | type                                                        | required | default           | description                                                                                |
+| ----------------------- | ----------------------------------------------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------ |
+| `sha`                   | string                                                      |          | ${{ github.sha }} | Commit hash that will be used as a tag for the Docker image                                |
+| `image-name`            | string                                                      | ✅        |                   | Name of the Docker image. Might be used in the next steps (for ex.: deploy a Docker image) |
+| `build-args`            | string                                                      |          |                   | Multiline string to describe build arguments that will be used during dockerization        |
+| `environment`           | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging           | Determines additional procedures while creating a Docker image.                            |
+| `docker-file`           | string                                                      |          | Dockerfile        | pathname to Dockerfile                                                                     |
+| `davinci-branch`        | string                                                      |          | master            | Custom davinci branch                                                                      |
+| `labels`                | string                                                      |          |                   | List of metadata for the Docker image                                                      |
+| `context`               | string                                                      |          | .                 | Build context                                                                              |
+| `push`                  | string                                                      |          | true              | Push the image to the registry                                                             |
+| `platforms`             | string                                                      |          | linux/amd64       | List of target platforms for build                                                         |
+| `tags`                  | string                                                      |          |                   | Additional tags for the Docker image                                                       |
+| `target`                | string                                                      |          |                   | Sets the target stage to build                                                             |
+| `checkout-davinci`      | string                                                      |          | false             | Checkout davinci repository                                                                |
+| `registry-name`         | string                                                      | ✅        |                   | Registry to push the builded image                                                         |
+| `gh-runner-driver-opts` | string                                                      |          |                   | Driver options for GH Runners                                                              |
 
 ### Outputs
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -61,6 +61,11 @@ inputs:
   registry-name:
     required: true
     description: 'Registry to push the builded image'
+  gh-runner-driver-opts:
+    required: false
+    description: 'Driver options for GH Runners'
+    default: |
+      image=moby/buildkit:buildx-stable-1
 
 runs:
   using: composite
@@ -123,6 +128,9 @@ runs:
     - name: Set up Docker Buildx - GH runners
       if: "!(contains(runner.name, 'inf-gha-runners') && contains(runner.name, 'ubuntu2204'))"
       uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: ${{ inputs.gh-runner-driver-opts }}
+
 
     - name: Build and push release image
       uses: docker/build-push-action@v5

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -64,8 +64,6 @@ inputs:
   gh-runner-driver-opts:
     required: false
     description: 'Driver options for GH Runners'
-    default: |
-      image=moby/buildkit:buildx-stable-1
 
 runs:
   using: composite
@@ -130,7 +128,6 @@ runs:
       uses: docker/setup-buildx-action@v3
       with:
         driver-opts: ${{ inputs.gh-runner-driver-opts }}
-
 
     - name: Build and push release image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
### Description

Add `gh-runners-driver-opts` input in build-push action.

We can use a custom image to avou DockerHub Rate limit errors like: 
`Fix Error: ERROR: Error response from daemon: No such image: moby/buildkit:buildx-stable-1` / `ERROR: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`

### How to test

- Action is green in a workflow using it

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
