### PR TITLE
[FX-NULL] Pass parameter to build-push-image

### DIFF
--- a/.changeset/nervous-oranges-obey.md
+++ b/.changeset/nervous-oranges-obey.md
@@ -1,0 +1,5 @@
+---
+'davinci-github-actions': minor
+---
+
+- add `gh-runner-driver-opts` parameter to `build-push-release-image` action

--- a/build-push-release-image/README.md
+++ b/build-push-release-image/README.md
@@ -10,14 +10,15 @@ This GH Action builds a Docker [release image](https://github.com/toptal/davinci
 
 The list of arguments, that are used in GH Action:
 
-| name              | type                                                        | required | default | description                                                                                                         |
-| ----------------- | ----------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `sha`             | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image                                                         |
-| `repository-name` | string                                                      | ✅        |         | Name of repository. It's used to determine an image name                                                            |
-| `environment`     | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Used to determine additional procedures while creating a Docker image                                               |
-| `dist-folder`     | string                                                      |          | ./dist  | Path to the folder with the built project                                                                           |
-| `scope`           | string                                                      |          |         | Used to determine the scope of the built project. Usefull in multihost monorepo projects to build only one project. |
-| `node-version`    | string                                                      |          | 20      | Node.js version used. The action is guaranteed to work only with Node.js@20 (default value)                         |
+| name                    | type                                                        | required | default | description                                                                                                         |
+| ----------------------- | ----------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `sha`                   | string                                                      | ✅        |         | Commit hash that will be used as a tag for the Docker image                                                         |
+| `repository-name`       | string                                                      | ✅        |         | Name of repository. It's used to determine an image name                                                            |
+| `environment`           | enum<<br/>`temploy`,<br/>`staging`,<br/>`production`,<br/>> |          | staging | Used to determine additional procedures while creating a Docker image                                               |
+| `dist-folder`           | string                                                      |          | ./dist  | Path to the folder with the built project                                                                           |
+| `scope`                 | string                                                      |          |         | Used to determine the scope of the built project. Usefull in multihost monorepo projects to build only one project. |
+| `node-version`          | string                                                      |          | 20      | Node.js version used. The action is guaranteed to work only with Node.js@20 (default value)                         |
+| `gh-runner-driver-opts` | string                                                      |          |         | Driver options for GH Runners                                                                                       |
 
 ### Outputs
 

--- a/build-push-release-image/action.yml
+++ b/build-push-release-image/action.yml
@@ -29,6 +29,9 @@ inputs:
     required: false
     default: 20
     description: 'Node.js version used. The action is guaranteed to work only with Node.js@20 (default value)'
+  gh-runner-driver-opts:
+    required: false
+    description: 'Driver options for GH Runners'
 
 runs:
   using: composite
@@ -46,13 +49,14 @@ runs:
           yarn lerna run build --scope=${{ inputs.scope}}
         fi
 
-    - uses: toptal/davinci-github-actions/build-push-image@v14.0.0
+    - uses: toptal/davinci-github-actions/build-push-image@v15.5.0
       with:
         sha: ${{ inputs.sha }}
         image-name: ${{ inputs.repository-name }}-release
         environment: ${{ inputs.environment }}
         node-version: ${{ inputs.node-version }}
         docker-file: ./davinci/packages/ci/src/configs/docker/Dockerfile.gha-deploy
+        gh-runner-driver-opts: ${{ inputs.gh-runner-driver-opts }}
         build-args: |
           ENV_RUNTIME_ENTRYPOINT=./davinci/packages/ci/src/configs/docker/env-runtime.entrypoint.sh
           DIST_FOLDER=${{ inputs.dist-folder }}


### PR DESCRIPTION
### Description

Similar to https://github.com/toptal/davinci-github-actions/pull/356, we want to pass options to `buildx` in `build-push-release-image` job.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>
