### PR TITLE
Fix usage of custom path in yarn-install

### DIFF
--- a/.changeset/nice-seahorses-buy.md
+++ b/.changeset/nice-seahorses-buy.md
@@ -1,0 +1,9 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### yarn-install
+
+- fix for custom usage of path parameter. If path input parameter is used - use `yarn.lock` file from that path to generate cache hash.

--- a/.changeset/nice-seahorses-buy.md
+++ b/.changeset/nice-seahorses-buy.md
@@ -3,7 +3,6 @@
 ---
 
 ---
-
 ### yarn-install
 
 - fix for custom usage of path parameter. If path input parameter is used - use `yarn.lock` file from that path to generate cache hash.

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -70,7 +70,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles(format('{0}/yarn.lock', inputs.path), format('{0}/tmp-workspaces.json', inputs.path)) }}-${{ inputs.cache-version }}
 
     - name: Cache yarn and node_modules folder
       if: "!(inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204')))"
@@ -83,7 +83,7 @@ runs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles('yarn.lock', 'tmp-workspaces.json') }}-${{ inputs.cache-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles(format('{0}/yarn.lock', inputs.path), format('{0}/tmp-workspaces.json', inputs.path)) }}-${{ inputs.cache-version }}
 
     - name: Delete temporary tmp-workspaces.json
       shell: bash


### PR DESCRIPTION
### Description

Fix for custom usage of path parameter. If path input parameter is used - use `yarn.lock` file from that path to generate cache hash.

The modified GHA is tested in https://github.com/toptal/client-portal/actions/runs/12235817455 (https://github.com/toptal/client-portal/pull/10141)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>
