### PR TITLE
Simplify the way yarn-install action ensures yarn.lock stays unchanged after `yarn install`

### DIFF
--- a/.changeset/fuzzy-bees-applaud.md
+++ b/.changeset/fuzzy-bees-applaud.md
@@ -1,0 +1,5 @@
+---
+"davinci-github-actions": patch
+---
+
+Simplify the way yarn-install action ensures yarn.lock is unchanged after `yarn install`

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -112,41 +112,41 @@ runs:
     - name: Change registry in yarn.lock file to npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
       shell: bash
+      working-directory: ${{ inputs.path }}
       run: |
-        echo "Creating temporary files for processing"
-        touch ${{ inputs.path }}/yarn.lock.tmp
-        touch ${{ inputs.path }}/yarn.lock.toptal
-
-        echo "Extracting npmjs.org entries (excluding @toptal/@topkit)"
-        if grep -q 'registry.npmjs.org' ${{ inputs.path }}/yarn.lock; then
-          grep 'registry.npmjs.org' ${{ inputs.path }}/yarn.lock | grep -v '/@toptal\|/@topkit' | awk '{print $2 " " $2}' > ${{ inputs.path }}/yarn.lock.tmp
-        fi
+        echo "Snapshot original yarn.lock file to restore it later"
+        cp yarn.lock yarn.lock.original
 
         echo "Extracting @toptal and @topkit entries"
-        if grep -q '/@toptal\|/@topkit' ${{ inputs.path }}/yarn.lock; then
-          grep '/@toptal\|/@topkit' ${{ inputs.path }}/yarn.lock | awk '{print $2 " " $2}' > ${{ inputs.path }}/yarn.lock.toptal
+        touch yarn.lock.toptal
+        if grep -q '/@toptal\|/@topkit' yarn.lock; then
+          grep '/@toptal\|/@topkit' yarn.lock | awk '{print $2 " " $2}' > yarn.lock.toptal
         fi
 
-        echo "Changing the URLs to the new registry for files created in the previous steps, creating a TO/FROM list to be used when reverting back the URLs to the original registry"
-        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.tmp
-        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.tmp
-        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.toptal
-        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.toptal
+        echo "Changing the URLs to the new registry for @toptal and @topkit entries, creating a TO/FROM list to be used when reverting back the URLs to the original registry"
+        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" yarn.lock.toptal
+        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" yarn.lock.toptal
 
-        echo "Changing the URLs to AR registry for all ocurrences"
-        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
-        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
+        echo "Changing the URLs to AR registry for all occurrences"
+        sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" yarn.lock
+        sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" yarn.lock
 
         echo "Removing double quotes from the URLs"
-        sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.tmp
-        sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.toptal
+        sed -i -e "s/\"//g" yarn.lock.toptal
 
         echo "Reverting the @toptal and @topkit packages to the original registry, working on revert fewer ocurrences (specific list) is faster than loop all the file"
         while read -r line; do
           url1="$(awk '{ print $1 }' <<<"$line")"
           url2="$(awk '{ print $2 }' <<<"$line")"
-          sed -i -e "s~${url1}~${url2}~" ${{ inputs.path }}/yarn.lock
-        done < ${{ inputs.path }}/yarn.lock.toptal
+          sed -i -e "s~${url1}~${url2}~" yarn.lock
+        done < yarn.lock.toptal
+
+    - name: Capture yarn.lock file checksum
+      id: yarn-lock-checksum
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        echo "checksum=$(cksum yarn.lock)" >> $GITHUB_OUTPUT
 
     - name: yarn install
       shell: bash
@@ -161,26 +161,22 @@ runs:
           sleep 10 # 10s wait time
         done
 
-    # Revert the URLs to the original registry
-    - name: Revert URLs to original registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
-      shell: bash
-      run: |
-        echo "Reverting specific URLs to npmjs.org"
-        while read -r line; do
-          url1="$(awk '{ print $1 }' <<<"$line")"
-          url2="$(awk '{ print $2 }' <<<"$line")"
-          sed -i -e "s~${url1}~${url2}~" ${{ inputs.path }}/yarn.lock
-        done < ${{ inputs.path }}/yarn.lock.tmp
-
-        echo "Reverting the leftovers URLs to yarnpkg.org registry"
-        sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#https://registry.yarnpkg.com/#g" ${{ inputs.path }}/yarn.lock
-
       # We are manually checking for the changes in yarn.lock file, because
       # the `--frozen-lockfile` flag is not working correctly in workspaces with yarn v1
       # we can remove this step when we upgrade yarn or migrate to other package manager
-    - name: Check for changes
+    - name: Verify yarn.lock is unchanged
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-        git diff --exit-code yarn.lock || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)
+        [ "${{ steps.yarn-lock-checksum.outputs.checksum }}" = "$(cksum yarn.lock)" ] || (echo 'yarn.lock changed after yarn install. Please make sure to commit yarn.lock changes.' && exit 1)
+
+      # Undo any modifications to yarn.lock we might have done to leave
+      # repo in the same state as it was before running yarn-install action
+    - name: Restore original yarn.lock
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [ -f yarn.lock.original ]; then
+          cp yarn.lock.original yarn.lock
+          rm yarn.lock.original
+        fi


### PR DESCRIPTION
### Background

I have faced a problem integrating yarn-install action into [tracker-front](https://github.com/toptal/tracker-front) where we have yarn.lock that gets all packages through registry.yarnpkg.com, so not a single mention of registry.npmjs.com is there, and this leads to `Change registry in yarn.lock file to npm Artifact Registry` step failing with an error (e.g. https://github.com/toptal/tracker-front/actions/runs/12527127099/job/34940394300?pr=3264)
<img src="https://github.com/user-attachments/assets/e0caf0cd-6e51-4566-864b-368eb2c8bfaf" width="250" />

Initially tried to hunt down and fix this specific problem, but debugging this quite complex bash script came to conclusion it's kind of overengineered and we can achieve the same behavior with much more simple and even more performant implementation. Thus this is my suggestion

### Description

The idea if existing implementation is that after running yarn install we process entire yarn.lock and undo any registry overrides that we've done previously so we can compare yarn.lock after yarn install to one in git index. 

The idea of updated implementation is that we capture checksum of the yarn.lock right before running `yarn install` (with overridden URLs) and compare it to checksum after yarn install

### How to test

- Check `yarn-install` works as expected on different toptal repos
- - success path - yarn-install passes when yarn.lock is up to date with package.json 
- - failure path - yarn-install fails when yarn.lock is to up to date with package.json 
- [x] toptal/staff-portal
- - success path - https://github.com/toptal/staff-portal/actions/runs/12668795818/job/35304940896?pr=14098#step:7:592
- - failure path - https://github.com/toptal/staff-portal/actions/runs/12668795818/job/35304940896?pr=14098#step:7:592
- [x] toptal/hire-global
- - success path - https://github.com/toptal/hire-global/actions/runs/12640219148/job/35220183956?pr=520#step:7:556
- - failure path - https://github.com/toptal/hire-global/actions/runs/12640053550/job/35219662580?pr=520#step:7:583

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>
