### PR TITLE
[TAPS-425] Improve yarn-install action

### DIFF
--- a/.changeset/hip-coins-bathe.md
+++ b/.changeset/hip-coins-bathe.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+### yarn-install
+
+- improve `yarn-install` action for scenario when there is no occurrence of `registry.npmjs.org` inside `yarn.lock`

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -113,27 +113,35 @@ runs:
       if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
       shell: bash
       run: |
-        # Create a copy of specific URLs (npmjs.org, @toptal and @topkit) and since they are fewer to restore them back at later steps
-        grep registry.npmjs.org ${{ inputs.path }}/yarn.lock | grep -v '/@toptal\|/@topkit' | awk '{print $2 " " $2}' > ${{ inputs.path }}/yarn.lock.tmp
-        grep '/@toptal\|/@topkit' ${{ inputs.path }}/yarn.lock | awk '{print $2 " " $2}' >> ${{ inputs.path }}/yarn.lock.toptal
+        echo "Creating temporary files for processing"
+        touch ${{ inputs.path }}/yarn.lock.tmp
+        touch ${{ inputs.path }}/yarn.lock.toptal
 
-        # Change the URLs to the new registry for files created in the previous steps
-        # Creates a TO/FROM list to be used when reverting back the URLs to the original registry
+        echo "Extracting npmjs.org entries (excluding @toptal/@topkit)"
+        if grep -q 'registry.npmjs.org' ${{ inputs.path }}/yarn.lock; then
+          grep 'registry.npmjs.org' ${{ inputs.path }}/yarn.lock | grep -v '/@toptal\|/@topkit' | awk '{print $2 " " $2}' > ${{ inputs.path }}/yarn.lock.tmp
+        fi
+
+        echo "Extracting @toptal and @topkit entries"
+        if grep -q '/@toptal\|/@topkit' ${{ inputs.path }}/yarn.lock; then
+          grep '/@toptal\|/@topkit' ${{ inputs.path }}/yarn.lock | awk '{print $2 " " $2}' > ${{ inputs.path }}/yarn.lock.toptal
+        fi
+
+        echo "Changing the URLs to the new registry for files created in the previous steps, creating a TO/FROM list to be used when reverting back the URLs to the original registry"
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.tmp
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.tmp
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.toptal
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#" ${{ inputs.path }}/yarn.lock.toptal
 
-        # Change the URLs to AR registry for all ocurrences
+        echo "Changing the URLs to AR registry for all ocurrences"
         sed -i -e "s#https://registry.yarnpkg.com/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
         sed -i -e "s#https://registry.npmjs.org/#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#g" ${{ inputs.path }}/yarn.lock
 
-        # Remove double quotes from the URLs
+        echo "Removing double quotes from the URLs"
         sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.tmp
         sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.toptal
 
-        # Revert the @toptal and @topkit packages to the original registry
-        # Working on revert fewer ocurrences (specific list) is faster than loop all the file
+        echo "Revering the @toptal and @topkit packages to the original registry, working on revert fewer ocurrences (specific list) is faster than loop all the file"
         while read -r line; do
           url1="$(awk '{ print $1 }' <<<"$line")"
           url2="$(awk '{ print $2 }' <<<"$line")"
@@ -153,21 +161,19 @@ runs:
           sleep 10 # 10s wait time
         done
 
-
-
     # Revert the URLs to the original registry
     - name: Revert URLs to original registry
       if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
       shell: bash
       run: |
-        # Revert specific URLs to npmjs.org
+        echo "Reverting specific URLs to npmjs.org"
         while read -r line; do
           url1="$(awk '{ print $1 }' <<<"$line")"
           url2="$(awk '{ print $2 }' <<<"$line")"
           sed -i -e "s~${url1}~${url2}~" ${{ inputs.path }}/yarn.lock
         done < ${{ inputs.path }}/yarn.lock.tmp
 
-        # Revert the leftovers URLs to yarnpkg.org registry
+        echo "Reverting the leftovers URLs to yarnpkg.org registry"
         sed -i -e "s#https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/#https://registry.yarnpkg.com/#g" ${{ inputs.path }}/yarn.lock
 
       # We are manually checking for the changes in yarn.lock file, because

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -141,7 +141,7 @@ runs:
         sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.tmp
         sed -i -e "s/\"//g" ${{ inputs.path }}/yarn.lock.toptal
 
-        echo "Revering the @toptal and @topkit packages to the original registry, working on revert fewer ocurrences (specific list) is faster than loop all the file"
+        echo "Reverting the @toptal and @topkit packages to the original registry, working on revert fewer ocurrences (specific list) is faster than loop all the file"
         while read -r line; do
           url1="$(awk '{ print $1 }' <<<"$line")"
           url2="$(awk '{ print $2 }' <<<"$line")"


### PR DESCRIPTION
[TAPS-425]

### Description

This PR aims to improve `yarn-install` action for scenario when there is no occurrence of `registry.npmjs.org` inside `yarn.lock`. We have this case in screening-wizard-frontend.

### How to test

- Review testing run: https://github.com/toptal/platform/actions/runs/12632044990 (PR with inlining `yarn-install` into platform to test changes: https://github.com/toptal/platform/pull/80504/files)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>


[TAPS-425]: https://toptal-core.atlassian.net/browse/TAPS-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ