### PR TITLE
Update github actions from v3 to v4

### DIFF
--- a/.changeset/polite-balloons-melt.md
+++ b/.changeset/polite-balloons-melt.md
@@ -1,0 +1,13 @@
+---
+'davinci-github-actions': patch
+---
+
+---
+
+### integration-tests
+
+- update github actions from v3 to v4
+
+### generate-gql-types
+
+- update github actions from v3 to v4

--- a/create-matrix/README.md
+++ b/create-matrix/README.md
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Matrix
         id: set-matrix

--- a/generate-gql-types/action.yml
+++ b/generate-gql-types/action.yml
@@ -1,11 +1,11 @@
 name: Generate GQL Types
 description: Generate graphql types before application build
-    
+
 inputs:
   generate-types-command:
     description: Command to generate gql types
     default: generate:types
-  gcr-gql-schemas-bucket-token: 
+  gcr-gql-schemas-bucket-token:
     description: Necessary token to pull gql schema from google cloud
     required: true
 
@@ -22,7 +22,7 @@ runs:
       uses: google-github-actions/setup-gcloud@v1.1.1
 
     - name: Check types cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: gql-types-cache
       with:
         path: |

--- a/integration-tests/action.yml
+++ b/integration-tests/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Cache Cypress folder
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: '~/.cache/Cypress'
         key: cypress-${{ hashFiles('**/yarn.lock') }}
@@ -36,7 +36,7 @@ runs:
       run: yarn $COMMAND
 
     - name: Store Cypress Screenshots Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-screenshots

--- a/report-missing-changeset/README.md
+++ b/report-missing-changeset/README.md
@@ -28,7 +28,7 @@ Not specified
 
 ```yaml
   - name: Checkout
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
     with:
       fetch-depth: 0
 


### PR DESCRIPTION
### Description

Started to see issues like this in some repos:

<img width="1137" alt="Screenshot 2025-01-16 at 17 30 16" src="https://github.com/user-attachments/assets/2c428b8b-65f6-4ba9-935c-4fa1def018d1" />

[link to the failed workflow](https://github.com/toptal/staff-portal/actions/runs/12811334688/job/35725271461)

So updating usage of github actions from v3 to v4

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>
