### PR TITLE
[TAPS-507 Fix yarn-install action

### DIFF
--- a/.changeset/perfect-cars-relate.md
+++ b/.changeset/perfect-cars-relate.md
@@ -1,0 +1,7 @@
+---
+'davinci-github-actions': patch
+---
+
+### yarn-install
+
+- fix `yarn-install` action for scenario when `.npmrc` file was changed

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -182,3 +182,11 @@ runs:
           cp yarn.lock.original yarn.lock
           rm yarn.lock.original
         fi
+
+    - name: Revert .npmrc changes
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [ -f .npmrc ]; then
+          git checkout -- .npmrc
+        fi
+      shell: bash


### PR DESCRIPTION
[TAPS-507]

This PR aims to fix `yarn-install` action which changes the `.npmrc` file, example of the Graphql schema update PR which contains unexpected `.npmrc` file change: https://github.com/toptal/talent-portal-frontend/pull/6676

### How to test
- review the run which contains the fix from this PR: https://github.com/toptal/talent-portal-frontend/actions/runs/13131796175/job/36638348074
- review the Schema Update PR which was created with the with from this PR: https://github.com/toptal/talent-portal-frontend/pull/6684

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>


[TAPS-507]: https://toptal-core.atlassian.net/browse/TAPS-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ