### PR TITLE
[TAPS-507] Use `mv` and `cp` commands to restore original `.npmrc` file instead of `git`

### DIFF
--- a/.changeset/clean-moons-look.md
+++ b/.changeset/clean-moons-look.md
@@ -1,0 +1,14 @@
+---
+'davinci-github-actions': patch
+---
+
+### yarn-install
+
+- fix `yarn-install` action for scenario when calling `git checkout -- .npmrc`, the example error:
+
+```bash
+fatal: detected dubious ownership in repository at '/__w/talent-portal-frontend/talent-portal-frontend'
+To add an exception for this directory, call:
+
+	git config --global --add safe.directory /__w/talent-portal-frontend/talent-portal-frontend
+```

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -95,6 +95,10 @@ runs:
     - name: Create .npmrc file using npm Artifact Registry
       if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
       run: |
+        if [ -f ${{ inputs.path }}/.npmrc ]; then
+          mv ${{ inputs.path }}/.npmrc ${{ inputs.path }}/.npmrc.original
+        fi
+
         echo "registry=https://us-central1-npm.pkg.dev/toptal-ci/npm-registry/" > ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:username=_json_key_base64" >> ${{ inputs.path }}/.npmrc &&
         echo "//us-central1-npm.pkg.dev/toptal-ci/npm-registry/:_password=${{ inputs.npm-gar-token }}" >> ${{ inputs.path }}/.npmrc &&
@@ -183,10 +187,11 @@ runs:
           rm yarn.lock.original
         fi
 
-    - name: Revert .npmrc changes
+    - name: Restore original .npmrc
       working-directory: ${{ inputs.path }}
       run: |
-        if [ -f .npmrc ]; then
-          git checkout -- .npmrc
+        if [ -f .npmrc.original ]; then
+          cp .npmrc.original .npmrc
+          rm .npmrc.original
         fi
       shell: bash


### PR DESCRIPTION
[TAPS-507]

This PR fixes error in https://github.com/toptal/talent-portal-frontend/actions/runs/13133866860/job/36644938912#step:9:398
```bash
fatal: detected dubious ownership in repository at '/__w/talent-portal-frontend/talent-portal-frontend'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/talent-portal-frontend/talent-portal-frontend
Error: Process completed with exit code 128.
```

### How to test

- Green CI in following repositories (where we used `yarn-install` from this PR):
  - https://github.com/toptal/screening-wizard-frontend/pull/1754, run: https://github.com/toptal/screening-wizard-frontend/actions/runs/13153753165?pr=1754
  - https://github.com/toptal/client-portal/pull/10307, run: https://github.com/toptal/client-portal/actions/runs/13153722806?pr=10307
  - https://github.com/toptal/talent-portal-frontend/pull/6686, run: https://github.com/toptal/talent-portal-frontend/actions/runs/13151224245?pr=6686

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>


[TAPS-507]: https://toptal-core.atlassian.net/browse/TAPS-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ