### PR TITLE
[OPS-657] Add auth to davinci-yarn-install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ anvil_test_results.json
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+.vscode

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -41,6 +41,14 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.npm-token || env.NPM_TOKEN }}
 
+    - name: Detect caching strategy
+      id: caching-strategy
+      shell: bash
+      run: |
+        echo "Check if we can cache deps on Toptal's infrastructure by using toptal/actions/cache"
+        echo "use_toptal_cache=${{inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))}}" >> $GITHUB_OUTPUT
+
+
     # This step is needed only because we want to update the cache when a new workspace
     # package has been added and we want symlinks to be presented in ./node_modules folder
     - name: Generate workspaces info
@@ -52,7 +60,7 @@ runs:
       shell: bash
 
     - name: Checkout `cache action` from actions repository
-      if: "inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       uses: actions/checkout@v4
       with:
         repository: toptal/actions
@@ -61,6 +69,7 @@ runs:
 
     - name: Decode Service Account JSON
       id: decode-sa
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       run: |
         DECODED_JSON=$(echo "${{ inputs.npm-gar-token }}" | base64 -d | tr -d '\n' | base64 -d)
         EOF=$(openssl rand -base64 12 | tr -d '\n') # Unique delimiter
@@ -70,13 +79,14 @@ runs:
       shell: bash
 
     - name: Authenticate to Google Cloud
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ steps.decode-sa.outputs.credentials_json }}
         project_id: toptal-production
 
     - name: Cache yarn and node_modules folder
-      if: "inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       uses: ./.github/cache_action/cache/
       id: node-modules-cache-custom
       with:
@@ -89,7 +99,7 @@ runs:
         key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles(format('{0}/yarn.lock', inputs.path), format('{0}/tmp-workspaces.json', inputs.path)) }}-${{ inputs.cache-version }}
 
     - name: Cache yarn and node_modules folder
-      if: "!(inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204')))"
+      if: steps.caching-strategy.outputs.use_toptal_cache != 'true'
       uses: actions/cache@v4
       id: node-modules-cache
       with:
@@ -109,7 +119,7 @@ runs:
     # This step creates .npmrc file that references to npm registry in GAR (Google Artifact Registry)
     # The npm registry works as a proxy-cache, downloading and storing the public npm packages
     - name: Create .npmrc file using npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       run: |
         if [ -f ${{ inputs.path }}/.npmrc ]; then
           mv ${{ inputs.path }}/.npmrc ${{ inputs.path }}/.npmrc.original
@@ -130,7 +140,7 @@ runs:
     # This step changes the public npm registry in yarn.lock file to npm in AR
     # We still use the public npm registry to our private packages
     - name: Change registry in yarn.lock file to npm Artifact Registry
-      if: "inputs.checkout-token && inputs.npm-gar-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
+      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -64,6 +64,8 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: toptal/actions
+        # TODO: reset to specific version
+        ref: explicit-auth-for-cache-action
         token: ${{ inputs.checkout-token }}
         path: ./.github/cache_action/
 
@@ -78,13 +80,6 @@ runs:
         echo "$EOF" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Authenticate to Google Cloud
-      if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: ${{ steps.decode-sa.outputs.credentials_json }}
-        project_id: toptal-production
-
     - name: Cache yarn and node_modules folder
       if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
       uses: ./.github/cache_action/cache/
@@ -97,6 +92,7 @@ runs:
           ${{ steps.yarn-cache.outputs.dir }}
           **/node_modules
         key: ${{ runner.os }}-${{ runner.arch }}-node-${{ steps.set-node-version.outputs.version }}-yarn-node_modules-${{ hashFiles(format('{0}/yarn.lock', inputs.path), format('{0}/tmp-workspaces.json', inputs.path)) }}-${{ inputs.cache-version }}
+        credentials-json: ${{ steps.decode-sa.outputs.credentials_json }}
 
     - name: Cache yarn and node_modules folder
       if: steps.caching-strategy.outputs.use_toptal_cache != 'true'

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -75,18 +75,12 @@ runs:
       shell: bash
       run: |
         DECODED_JSON=$(echo "${{ inputs.npm-gar-token }}" | base64 -d | tr -d '\n' | base64 -d)
+        # Convert to single line by removing newlines and extra spaces
+        SINGLE_LINE_DECODED_JSON=$(echo "$DECODED_JSON" | tr -d '\n' | tr -s ' ')
 
-        echo "Mask the private key of the service account JSON"
-        echo "$DECODED_JSON" | while IFS= read -r line; do
-          if [[ $line == *"BEGIN PRIVATE KEY"* ]]; then
-            echo "::add-mask::$line"
-          fi
-        done
+        echo "::add-mask::$SINGLE_LINE_DECODED_JSON"
 
-        EOF=$(openssl rand -base64 12 | tr -d '\n') # Unique delimiter
-        echo "credentials_json<<$EOF" >> $GITHUB_OUTPUT
-        echo "$DECODED_JSON" >> $GITHUB_OUTPUT
-        echo "$EOF" >> $GITHUB_OUTPUT
+        echo "credentials_json=$SINGLE_LINE_DECODED_JSON" >> $GITHUB_OUTPUT
 
     - name: Cache yarn and node_modules folder
       if: steps.caching-strategy.outputs.use_toptal_cache == 'true'

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -72,13 +72,21 @@ runs:
     - name: Decode Service Account JSON
       id: decode-sa
       if: steps.caching-strategy.outputs.use_toptal_cache == 'true'
+      shell: bash
       run: |
         DECODED_JSON=$(echo "${{ inputs.npm-gar-token }}" | base64 -d | tr -d '\n' | base64 -d)
+
+        echo "Mask the private key of the service account JSON"
+        echo "$DECODED_JSON" | while IFS= read -r line; do
+          if [[ $line == *"BEGIN PRIVATE KEY"* ]]; then
+            echo "::add-mask::$line"
+          fi
+        done
+
         EOF=$(openssl rand -base64 12 | tr -d '\n') # Unique delimiter
         echo "credentials_json<<$EOF" >> $GITHUB_OUTPUT
         echo "$DECODED_JSON" >> $GITHUB_OUTPUT
         echo "$EOF" >> $GITHUB_OUTPUT
-      shell: bash
 
     - name: Cache yarn and node_modules folder
       if: steps.caching-strategy.outputs.use_toptal_cache == 'true'

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -59,6 +59,22 @@ runs:
         token: ${{ inputs.checkout-token }}
         path: ./.github/cache_action/
 
+    - name: Decode Service Account JSON
+      id: decode-sa
+      run: |
+        DECODED_JSON=$(echo "${{ inputs.npm-gar-token }}" | base64 -d | tr -d '\n' | base64 -d)
+        EOF=$(openssl rand -base64 12 | tr -d '\n') # Unique delimiter
+        echo "credentials_json<<$EOF" >> $GITHUB_OUTPUT
+        echo "$DECODED_JSON" >> $GITHUB_OUTPUT
+        echo "$EOF" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ steps.decode-sa.outputs.credentials_json }}
+        project_id: toptal-production
+
     - name: Cache yarn and node_modules folder
       if: "inputs.checkout-token && (contains(runner.name, 'inf-gha-runners') || contains(runner.name, 'ubuntu2204'))"
       uses: ./.github/cache_action/cache/


### PR DESCRIPTION
[OPS-657]

Every repo that relies on toptal/davinci-github-actions/yarn-install is unable to use Toptal's cache. You can see this in your githb actions logs. Even though most actions are still green, they are most probably way slower.

![image (8)](https://github.com/user-attachments/assets/0f7b8328-4f25-4561-a5aa-4bbcadfe42c0)

More context: https://toptal-core.slack.com/archives/C03VBF0J6/p1739447389762339

### How to test

- Check you can still install npm deps

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/davinci-github-actions/blob/master/_docs/contribution/changeset-guidelines.md) (if needed)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-anvil ping reviewers` - Ping teams for review

</details>


[OPS-657]: https://toptal-core.atlassian.net/browse/OPS-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ